### PR TITLE
Remove "here" links in the API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Via an undocumented `/upload` endpoint, there is the ability to generate presign
 
 ## Dockerfile
 
-There is a Dockerfile included that will turn the project into a Docker container. The container can be found [here](https://hub.docker.com/r/flasher/openaq-api/) and is currently mostly used for deployment purposes for [AWS ECS](https://aws.amazon.com/ecs/). If someone wanted to make it better for local development, that'd be a great PR!
+There is a Dockerfile included that will turn the project into a Docker container. [The container](https://hub.docker.com/r/flasher/openaq-api/) is currently mostly used for deployment purposes for [AWS ECS](https://aws.amazon.com/ecs/). If someone wanted to make it better for local development, that'd be a great PR!
 
 ## Contributing
 There are a lot of ways to contribute to this project, more details can be found in the [contributing guide](CONTRIBUTING.md).

--- a/header.md
+++ b/header.md
@@ -1,6 +1,6 @@
 ### Overview
 
-Welcome to the OpenAQ API! This API is used to power various [tools built by the community](https://openaq.org/#/community) as well as [openaq.org](https://openaq.org). 
+Welcome to the OpenAQ API! This API is used to power various [tools built by the community](https://openaq.org/#/community) as well as [openaq.org](https://openaq.org).
 
 If you have any problems, please create an issue on [GitHub](https://github.com/openaq/openaq-api/issues)!
 
@@ -14,4 +14,4 @@ There are IP-based limits imposed of ~2000 requests over a 5 minute period. If y
 
 ### License
 
-For the most up to date license information, please see [here](https://github.com/openaq/openaq-api/blob/develop/LICENSE.md).
+Please refer to the [most up to date license information](https://github.com/openaq/openaq-api/blob/develop/LICENSE.md).


### PR DESCRIPTION
This PR is related to Issue #432 - `Avoid "here" links in the API docs?`

I followed this really directly, by only modifying links with the word `here`. I would be happy to update others if that would be helpful.