### PR TITLE
typo handling for params in logging.py

### DIFF
--- a/openaq_fastapi/openaq_fastapi/models/logging.py
+++ b/openaq_fastapi/openaq_fastapi/models/logging.py
@@ -87,8 +87,9 @@ class HTTPLog(BaseLog):
 
     @validator("params_obj", always=True)
     def set_params_obj(cls, v, values) -> dict:
-        if "=" in values.get("params", ""):
-            return v or dict(x.split("=") for x in values["params"].split("&"))
+        params = values.get("params", "")
+        if "=" in params:
+            return v or dict(x.split("=", 1) for x in params.split("&") if "=" in x)
         else:
             return None
 


### PR DESCRIPTION
Closes #164 
This fix will only attempt to make a a dict with the param if it contains `=`, and if it does it will only split on the first occurrence of `=`