### PR TITLE
Updates to remove total/found from measurement endpoints

### DIFF
--- a/openaq_fastapi/openaq_fastapi/db.py
+++ b/openaq_fastapi/openaq_fastapi/db.py
@@ -133,12 +133,15 @@ class DB:
     async def fetchPage(self, query, kwargs):
         if "limit" in kwargs.keys():
             page = kwargs.get("page", 1)
-            kwargs["offset"] = abs((page - 1) * kwargs.get("limit"))
+            limit = kwargs.get("limit")
+            kwargs["offset"] = abs((page - 1) * limit)
 
         data = await self.fetch(query, kwargs)
         if len(data) > 0:
             if "found" in data[0].keys():
                 kwargs["found"] = data[0]["found"]
+            elif len(data) == limit:
+                kwargs["found"] = f">{limit}"
             else:
                 kwargs["found"] = len(data)
         else:

--- a/openaq_fastapi/openaq_fastapi/models/responses.py
+++ b/openaq_fastapi/openaq_fastapi/models/responses.py
@@ -25,7 +25,7 @@ class Meta(BaseModel):
     website: str = "/"
     page: int = 1
     limit: int = 100
-    found: int = 0
+    found: Union[int, str, None]
 
 
 class Date(BaseModel):

--- a/openaq_fastapi/openaq_fastapi/routers/averages.py
+++ b/openaq_fastapi/openaq_fastapi/routers/averages.py
@@ -98,8 +98,8 @@ async def averages_v3_get(
     if av.period_name in [None, "hour"]:
         # Query for hourly data
         sql = f"""
-        SELECT sy.sensor_nodes_id as id
-        , sn.site_name as name
+        SELECT sn.id
+        , sn.name
         , datetime as hour
         , datetime::date as day
         , date_trunc('month', datetime) as month
@@ -115,12 +115,10 @@ async def averages_v3_get(
         , h.first_datetime
         , h.last_datetime
         {query.fields()}
-        {query.total()}
         FROM hourly_data h
         JOIN sensors s USING (sensors_id)
         JOIN sensor_systems sy USING (sensor_systems_id)
-        JOIN sensor_nodes sn ON (sy.sensor_nodes_id = sn.sensor_nodes_id)
-        JOIN timezones ts ON (sn.timezones_id = ts.gid)
+        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
         JOIN measurands m ON (m.measurands_id = h.measurands_id)
         {query.where()}
         {query.pagination()}
@@ -141,8 +139,8 @@ async def averages_v3_get(
             factor = "to_char(datetime - '1sec'::interval, 'MM') as moy"
 
         sql = f"""
-        SELECT sn.sensor_nodes_id as id
-        , site_name as name
+        SELECT sn.id
+        , sn.name
         , {factor}
         , m.measurand as parameter
         , m.measurands_id as "parameterId"
@@ -152,11 +150,10 @@ async def averages_v3_get(
         , COUNT(1) as measurement_count
         , MIN(datetime) as first_datetime
         , MAX(datetime) as last_datetime
-        {query.total()}
         FROM hourly_data h
         JOIN sensors s ON (h.sensors_id = s.sensors_id)
         JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
-        JOIN sensor_nodes sn ON (sy.sensor_nodes_id = sn.sensor_nodes_id)
+        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
         JOIN measurands m ON (h.measurands_id = m.measurands_id)
         {query.where()}
         GROUP BY 1, 2, 3, 4, 5, 6, 7

--- a/openaq_fastapi/openaq_fastapi/routers/measurements.py
+++ b/openaq_fastapi/openaq_fastapi/routers/measurements.py
@@ -214,7 +214,6 @@ async def measurements_get(
                ELSE 'low-cost sensor'
                END as "sensorType"
         , sn.is_analysis
-        --, COUNT(1) OVER() as found
         FROM hourly_data h
         JOIN sensors s USING (sensors_id)
         JOIN sensor_systems sy USING (sensor_systems_id)
@@ -266,7 +265,6 @@ async def measurements_get_v1(
              'longitude', st_x(sn.geom)
         ) as coordinates
         , c.iso as country
-        , COUNT(1) OVER() as found
         FROM hourly_data h
         JOIN sensors s USING (sensors_id)
         JOIN sensor_systems sy USING (sensor_systems_id)

--- a/openaq_fastapi/openaq_fastapi/v3/models/queries.py
+++ b/openaq_fastapi/openaq_fastapi/v3/models/queries.py
@@ -379,11 +379,11 @@ class DateFromQuery(QueryBaseModel):
             return None
         elif isinstance(self.date_from, datetime):
             if self.date_from.tzinfo is None:
-                return "datetime > (:date_from::timestamp AT TIME ZONE tzid)"
+                return "datetime > (:date_from::timestamp AT TIME ZONE timezone)"
             else:
                 return "datetime > :date_from"
         elif isinstance(self.date_from, date):
-            return "datetime > (:date_from::timestamp AT TIME ZONE tzid)"
+            return "datetime > (:date_from::timestamp AT TIME ZONE timezone)"
 
 
 class DateToQuery(QueryBaseModel):
@@ -396,11 +396,11 @@ class DateToQuery(QueryBaseModel):
             return None
         elif isinstance(self.date_to, datetime):
             if self.date_to.tzinfo is None:
-                return "datetime <= (:date_to::timestamp AT TIME ZONE tzid)"
+                return "datetime <= (:date_to::timestamp AT TIME ZONE timezone)"
             else:
                 return "datetime <= :date_to"
         elif isinstance(self.date_to, date):
-            return "datetime <= (:date_to::timestamp AT TIME ZONE tzid)"
+            return "datetime <= (:date_to::timestamp AT TIME ZONE timezone)"
 
 
 class PeriodNames(str, Enum):

--- a/openaq_fastapi/openaq_fastapi/v3/models/responses.py
+++ b/openaq_fastapi/openaq_fastapi/v3/models/responses.py
@@ -16,7 +16,7 @@ class Meta(JsonBase):
     website: str = "/"
     page: int = 1
     limit: int = 100
-    found: int = 0
+    found: Union[int, str, None]
 
 
 class OpenAQResult(JsonBase):
@@ -25,7 +25,6 @@ class OpenAQResult(JsonBase):
 
 
 #
-
 
 class DatetimeObject(JsonBase):
     utc: str


### PR DESCRIPTION
I also updated the v3 endpoints that were using `sensor_nodes` to use the `locations_view_cached` table to help speed things up. That also required a change in the from/to queries to use `timezone` instead of the `tzid`, same value just different field name.