### PR TITLE
Added ability to increase the working memory for a given endpoint

### DIFF
--- a/openaq_api/openaq_api/db.py
+++ b/openaq_api/openaq_api/db.py
@@ -14,7 +14,6 @@ from asyncio.exceptions import TimeoutError
 from openaq_api.settings import settings
 
 from .models.responses import Meta, OpenAQResult
-from pydantic import BaseModel, validate_call
 
 logger = logging.getLogger("db")
 

--- a/openaq_api/openaq_api/db.py
+++ b/openaq_api/openaq_api/db.py
@@ -14,15 +14,19 @@ from asyncio.exceptions import TimeoutError
 from openaq_api.settings import settings
 
 from .models.responses import Meta, OpenAQResult
+from pydantic import BaseModel, validate_call
 
 logger = logging.getLogger("db")
 
+allowed_config_params = ['work_mem']
 
 def default(obj):
     return str(obj)
 
-
-def dbkey(m, f, query, args):
+# config is required as a placeholder here because of this
+# function is used in the `cached` decorator and without it
+# we will get a number of arguments error
+def dbkey(m, f, query, args, config = None):
     j = orjson.dumps(
         args, option=orjson.OPT_OMIT_MICROSECONDS, default=default
     ).decode()
@@ -84,14 +88,24 @@ class DB:
         return self.request.app.state.pool
 
     @cached(settings.API_CACHE_TIMEOUT, **cache_config)
-    async def fetch(self, query, kwargs):
+    async def fetch(self, query, kwargs, config = None):
         pool = await self.pool()
         start = time.time()
         logger.debug("Start time: %s\nQuery: %s \nArgs:%s\n", start, query, kwargs)
         rquery, args = render(query, **kwargs)
         async with pool.acquire() as con:
             try:
+				# a transaction is required to prevent auto-commit
+                tr = con.transaction()
+                if config is not None:
+                    await tr.start()
+                    for param, value in config.items():
+                        if param in allowed_config_params:
+                            q = f"SELECT set_config('{param}', $1, TRUE)"
+                            s = await con.execute(q, value)
+
                 r = await con.fetch(rquery, *args)
+                await tr.commit()
             except asyncpg.exceptions.UndefinedColumnError as e:
                 logger.error(f"Undefined Column Error: {e}\n{rquery}\n{kwargs}")
                 raise ValueError(f"{e}") from e
@@ -130,12 +144,12 @@ class DB:
             return r[0]
         return None
 
-    async def fetchPage(self, query, kwargs) -> OpenAQResult:
+    async def fetchPage(self, query, kwargs, config = None) -> OpenAQResult:
         page = kwargs.get("page", 1)
         limit = kwargs.get("limit", 1000)
         kwargs["offset"] = abs((page - 1) * limit)
 
-        data = await self.fetch(query, kwargs)
+        data = await self.fetch(query, kwargs, config)
         if len(data) > 0:
             if "found" in data[0].keys():
                 kwargs["found"] = data[0]["found"]

--- a/openaq_api/openaq_api/routers/averages.py
+++ b/openaq_api/openaq_api/routers/averages.py
@@ -79,6 +79,7 @@ async def averages_v2_get(
     db: DB = Depends(),
 ) -> AveragesResponse:
     query = QueryBuilder(av)
+    config = None
 
     if av.temporal in [None, "hour"]:
         # Query for hourly data
@@ -123,6 +124,7 @@ async def averages_v2_get(
         elif av.temporal == "moy":
             factor = "to_char(datetime - '1sec'::interval, 'MM') as moy"
 
+        config = {"work_mem": "512MB"}
         sql = f"""
         SELECT sn.id
         , sn.name
@@ -145,5 +147,5 @@ async def averages_v2_get(
         {query.pagination()}
     """
 
-    response = await db.fetchPage(sql, query.params())
+    response = await db.fetchPage(sql, query.params(), config)
     return response


### PR DESCRIPTION
  Parameters must be passed to the fetchPage method and included in
  the `allowed_config_params` list. Settings will be updated for just
  that transaction and then reset. See example in the averages endpoint.