### PR TITLE
Features/v3 annual averaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ openaq_api/openaq_api/templates/*
 openaq_api/openaq_api/static/assets/*
 .python-version
 Pipfile
+/openaq_api/venv/

--- a/openaq_api/openaq_api/main.py
+++ b/openaq_api/openaq_api/main.py
@@ -193,6 +193,7 @@ class OpenAQValidationResponse(BaseModel):
     detail: list[OpenAQValidationResponseDetail] | None = None
 
 
+
 @app.exception_handler(RequestValidationError)
 async def openaq_request_validation_exception_handler(
     request: Request, exc: RequestValidationError

--- a/openaq_api/openaq_api/routers/averages.py
+++ b/openaq_api/openaq_api/routers/averages.py
@@ -5,8 +5,8 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Query
 
 from openaq_api.v3.models.queries import (
-    DateFromQuery,
-    DateToQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
     Paging,
     TemporalQuery,
     QueryBaseModel,
@@ -59,8 +59,8 @@ class AveragesQueries(
     Paging,
     SpatialTypeQuery,
     LocationQuery,
-    DateFromQuery,
-    DateToQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
     ParametersQuery,
     TemporalQuery,
 ):
@@ -98,8 +98,8 @@ async def averages_v2_get(
         , m.measurands_id as "parameterId"
         , m.display as "displayName"
         , m.units as unit
-        , h.first_datetime
-        , h.last_datetime
+        , h.datetime_first as first_datetime
+        , h.datetime_last as last_datetime
         {query.fields()}
         FROM hourly_data h
         JOIN sensors s USING (sensors_id)

--- a/openaq_api/openaq_api/v3/models/queries.py
+++ b/openaq_api/openaq_api/v3/models/queries.py
@@ -537,7 +537,7 @@ class PeriodNameQuery(QueryBaseModel):
     """
 
     period_name: PeriodNames | None = Query(
-        "hour", description="Period to aggregate. Month, day, hour, hour of day (hod), day of week (dow) and month of year (moy)"
+        "hour", description="Period to aggregate. Year, month, day, hour, hour of day (hod), day of week (dow) and month of year (moy)"
     )
 
 

--- a/openaq_api/openaq_api/v3/models/queries.py
+++ b/openaq_api/openaq_api/v3/models/queries.py
@@ -464,6 +464,89 @@ class CountryIsoQuery(QueryBaseModel):
             return "country->>'code' = :iso"
 
 
+class DatetimeFromQuery(QueryBaseModel):
+    """Pydantic query model for the `datetime_from` query parameter
+
+    Inherits from QueryBaseModel
+
+    Attributes:
+        datetime_from: date or datetime in ISO-8601 format to filter results to a
+        date range.
+    """
+
+    datetime_from: datetime | date | None = Query(
+        None,
+        description="From when?",
+        examples=["2022-10-01T11:19:38-06:00", "2022-10-01"],
+    )
+
+
+    def where(self) -> str:
+        """Generates SQL condition for filtering to datetime.
+
+        Overrides the base QueryBaseModel `where` method
+
+        If `datetime_from` is a `date` or `datetime` without a timezone a timezone
+        is added as UTC.
+
+        Returns:
+            string of WHERE clause if `datetime_from` is set
+        """
+        tz = self.map('timezone', 'timezone')
+        dt = self.map('datetime', 'datetime')
+
+        if self.datetime_from is None:
+            return None
+        elif isinstance(self.datetime_from, datetime):
+            if self.datetime_from.tzinfo is None:
+                return f"{dt} > (:datetime_from::timestamp AT TIME ZONE {tz})"
+            else:
+                return f"{dt} > :datetime_from"
+        elif isinstance(self.datetime_from, date):
+            return f"{dt} > (:datetime_from::timestamp AT TIME ZONE {tz})"
+
+
+class DatetimeToQuery(QueryBaseModel):
+    """Pydantic query model for the `date_to` query parameter
+
+    Inherits from QueryBaseModel
+
+    Attributes:
+        date_to: date or datetime in ISO-8601 format to filter results to a
+        date range.
+    """
+
+    datetime_to: datetime | date | None = Query(
+        None,
+        description="To when?",
+        examples=["2022-10-01T11:19:38-06:00", "2022-10-01"],
+    )
+
+    def where(self) -> str:
+        """Generates SQL condition for filtering to datetime.
+
+        Overrides the base QueryBaseModel `where` method
+
+        If `datetime_to` is a `date` or `datetime` without a timezone a timezone
+        is added as UTC.
+
+        Returns:
+            string of WHERE clause if `datetime_to` is set
+        """
+        tz = self.map('timezone', 'timezone')
+        dt = self.map('datetime', 'datetime')
+
+        if self.datetime_to is None:
+            return None
+        elif isinstance(self.datetime_to, datetime):
+            if self.datetime_to.tzinfo is None:
+                return f"{dt} <= (:datetime_to::timestamp AT TIME ZONE {tz})"
+            else:
+                return f"{dt} <= :datetime_to"
+        elif isinstance(self.datetime_to, date):
+            return f"{dt} <= (:datetime_to::timestamp AT TIME ZONE {tz})"
+
+
 class DateFromQuery(QueryBaseModel):
     """Pydantic query model for the `date_from` query parameter
 
@@ -480,6 +563,7 @@ class DateFromQuery(QueryBaseModel):
         examples=["2022-10-01T11:19:38-06:00", "2022-10-01"],
     )
 
+
     def where(self) -> str:
         """Generates SQL condition for filtering to datetime.
 
@@ -491,18 +575,14 @@ class DateFromQuery(QueryBaseModel):
         Returns:
             string of WHERE clause if `date_from` is set
         """
-        tz = self.map('timezone', 'timezone')
         dt = self.map('datetime', 'datetime')
 
         if self.date_from is None:
             return None
         elif isinstance(self.date_from, datetime):
-            if self.date_from.tzinfo is None:
-                return f"{dt} > (:date_from::timestamp AT TIME ZONE {tz})"
-            else:
-                return f"{dt} > :date_from"
+            return f"{dt} >= :date_from::date"
         elif isinstance(self.date_from, date):
-            return f"{dt} > (:date_from::timestamp AT TIME ZONE {tz})"
+            return f"{dt} >= :date_from"
 
 
 class DateToQuery(QueryBaseModel):
@@ -521,7 +601,7 @@ class DateToQuery(QueryBaseModel):
         examples=["2022-10-01T11:19:38-06:00", "2022-10-01"],
     )
 
-    def where(self, q = None) -> str:
+    def where(self) -> str:
         """Generates SQL condition for filtering to datetime.
 
         Overrides the base QueryBaseModel `where` method
@@ -532,15 +612,14 @@ class DateToQuery(QueryBaseModel):
         Returns:
             string of WHERE clause if `date_to` is set
         """
+        dt = self.map('datetime', 'datetime')
+
         if self.date_to is None:
             return None
         elif isinstance(self.date_to, datetime):
-            if self.date_to.tzinfo is None:
-                return "datetime <= (:date_to::timestamp AT TIME ZONE timezone)"
-            else:
-                return "datetime <= :date_to"
+            return f"{dt} <= :date_to::date"
         elif isinstance(self.date_to, date):
-            return "datetime <= (:date_to::timestamp AT TIME ZONE timezone)"
+            return f"{dt} <= :date_to"
 
 
 class PeriodNames(StrEnum):
@@ -553,9 +632,6 @@ class PeriodNames(StrEnum):
     moy = "moy"
     raw = "raw"
 
-class BaseData(StrEnum):
-    hour = "hourly"
-    day = "daily"
 
 
 class PeriodNameQuery(QueryBaseModel):
@@ -571,21 +647,6 @@ class PeriodNameQuery(QueryBaseModel):
         "hour", description="Period to aggregate. Year, month, day, hour, hour of day (hod), day of week (dow) and month of year (moy)"
     )
 
-
-
-class BaseDataQuery(QueryBaseModel):
-    """Pydantic query model for the `base_data` query parameter.
-
-    Inherits from QueryBaseModel
-
-    Attributes:
-        base_data: the name of the underlying table to pull data from
-    """
-
-    base_data: BaseData | None = Query(
-        "hourly",
-        description="Base data to pull from. Options are hourly, daily"
-    )
 
 
 class TemporalQuery(QueryBaseModel):

--- a/openaq_api/openaq_api/v3/models/queries.py
+++ b/openaq_api/openaq_api/v3/models/queries.py
@@ -582,7 +582,7 @@ class DateFromQuery(QueryBaseModel):
         elif isinstance(self.date_from, datetime):
             return f"{dt} >= :date_from::date"
         elif isinstance(self.date_from, date):
-            return f"{dt} >= :date_from"
+            return f"{dt} >= :date_from::date"
 
 
 class DateToQuery(QueryBaseModel):
@@ -619,7 +619,7 @@ class DateToQuery(QueryBaseModel):
         elif isinstance(self.date_to, datetime):
             return f"{dt} <= :date_to::date"
         elif isinstance(self.date_to, date):
-            return f"{dt} <= :date_to"
+            return f"{dt} <= :date_to::date"
 
 
 class PeriodNames(StrEnum):

--- a/openaq_api/openaq_api/v3/models/queries.py
+++ b/openaq_api/openaq_api/v3/models/queries.py
@@ -526,6 +526,10 @@ class PeriodNames(StrEnum):
     moy = "moy"
     raw = "raw"
 
+class BaseData(StrEnum):
+    hour = "hourly"
+    day = "daily"
+
 
 class PeriodNameQuery(QueryBaseModel):
     """Pydantic query model for the `period_name` query parameter.
@@ -538,6 +542,21 @@ class PeriodNameQuery(QueryBaseModel):
 
     period_name: PeriodNames | None = Query(
         "hour", description="Period to aggregate. Year, month, day, hour, hour of day (hod), day of week (dow) and month of year (moy)"
+    )
+
+
+
+class BaseDataQuery(QueryBaseModel):
+    """Pydantic query model for the `base_data` query parameter.
+
+    Inherits from QueryBaseModel
+
+    Attributes:
+        base_data: the name of the underlying table to pull data from
+    """
+
+    base_data: BaseData | None = Query(
+        "hourly", description="Base data to pull from. Options are hourly, daily"
     )
 
 

--- a/openaq_api/openaq_api/v3/models/responses.py
+++ b/openaq_api/openaq_api/v3/models/responses.py
@@ -220,6 +220,36 @@ class Measurement(JsonBase):
     coverage: Coverage | None = None
 
 
+class HourlyData(JsonBase):
+    #datetime: DatetimeObject
+    value: float
+    parameter: ParameterBase
+    period: Period | None = None
+    coordinates: Coordinates | None = None
+    summary: Summary | None = None
+    coverage: Coverage | None = None
+
+
+class DailyData(JsonBase):
+    #datetime: DatetimeObject
+    value: float
+    parameter: ParameterBase
+    period: Period | None = None
+    coordinates: Coordinates | None = None
+    summary: Summary | None = None
+    coverage: Coverage | None = None
+
+
+class AnnualData(JsonBase):
+    #datetime: DatetimeObject
+    value: float
+    parameter: ParameterBase
+    period: Period | None = None
+    coordinates: Coordinates | None = None
+    summary: Summary | None = None
+    coverage: Coverage | None = None
+
+
 # Similar to measurement but without timestamps
 class Trend(JsonBase):
     factor: Factor
@@ -243,6 +273,15 @@ class LocationsResponse(OpenAQResult):
 
 class MeasurementsResponse(OpenAQResult):
     results: list[Measurement]
+
+class HourlyDataResponse(OpenAQResult):
+    results: list[HourlyData]
+
+class DailyDataResponse(OpenAQResult):
+    results: list[DailyData]
+
+class AnnualDataResponse(OpenAQResult):
+    results: list[AnnualData]
 
 
 class TrendsResponse(OpenAQResult):

--- a/openaq_api/openaq_api/v3/routers/measurements.py
+++ b/openaq_api/openaq_api/v3/routers/measurements.py
@@ -122,6 +122,8 @@ async def fetch_measurements(q, db):
             dur = "24:00:00"
         elif q.period_name == "month":
             dur = "1 month"
+        elif q.period_name == "year":
+            dur = "1 year"
 
         sql = f"""
             WITH meas AS (

--- a/openaq_api/openaq_api/v3/routers/measurements.py
+++ b/openaq_api/openaq_api/v3/routers/measurements.py
@@ -64,6 +64,8 @@ async def measurements_get(
     return response
 
 
+
+
 async def fetch_measurements(q, db):
     query = QueryBuilder(q)
     dur = "01:00:00"

--- a/openaq_api/openaq_api/v3/routers/measurements.py
+++ b/openaq_api/openaq_api/v3/routers/measurements.py
@@ -5,8 +5,8 @@ from fastapi import APIRouter, Depends, Path, Query
 from openaq_api.db import DB
 from openaq_api.v3.models.queries import (
     CommaSeparatedList,
-    DateFromQuery,
-    DateToQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
     Paging,
     PeriodNameQuery,
     QueryBaseModel,
@@ -41,8 +41,8 @@ class MeasurementsParametersQuery(QueryBaseModel):
 class LocationMeasurementsQueries(
     Paging,
     LocationPathQuery,
-    DateFromQuery,
-    DateToQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
     MeasurementsParametersQuery,
     PeriodNameQuery,
 ): ...
@@ -103,8 +103,8 @@ async def fetch_measurements(q, db):
         , s.data_logging_period_seconds
         , {expected_hours} * 3600
         )||jsonb_build_object(
-          'datetime_from', get_datetime_object(h.first_datetime, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
+          'datetime_from', get_datetime_object(h.datetime_first, sn.timezone)
+        , 'datetime_to', get_datetime_object(h.datetime_last, sn.timezone)
         ) as coverage
         {query.fields()}
         FROM hourly_data h

--- a/openaq_api/openaq_api/v3/routers/sensors.py
+++ b/openaq_api/openaq_api/v3/routers/sensors.py
@@ -11,6 +11,7 @@ from openaq_api.v3.models.queries import (
     DateToQuery,
     Paging,
     PeriodNameQuery,
+    BaseDataQuery,
     QueryBaseModel,
     QueryBuilder,
 )
@@ -52,6 +53,7 @@ class SensorMeasurementsQueries(
     SensorQuery,
     DateFromQuery,
     DateToQuery,
+    BaseDataQuery,
     PeriodNameQuery,
 ):
     @field_validator('date_to', 'date_from')
@@ -167,8 +169,9 @@ async def fetch_measurements(q, db):
     base_query_name = 'hourly_data'
     interval_seconds = 3600
 
-    #base_query_name = 'daily_data'
-    #interval_seconds = 3600 * 24
+    if q.base_data == 'daily':
+        base_query_name = 'daily_data'
+        interval_seconds = 3600 * 24
 
     if q.period_name in [None, "hour"]:
         # Query for hourly data

--- a/openaq_api/openaq_api/v3/routers/sensors.py
+++ b/openaq_api/openaq_api/v3/routers/sensors.py
@@ -2,16 +2,17 @@ import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Path, HTTPException
-from pydantic import field_validator
-from datetime import date, datetime
+from fastapi.exceptions import RequestValidationError
+from pydantic import model_validator
+from datetime import date, datetime, timedelta
 
 from openaq_api.db import DB
 from openaq_api.v3.models.queries import (
     DateFromQuery,
     DateToQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
     Paging,
-    PeriodNameQuery,
-    BaseDataQuery,
     QueryBaseModel,
     QueryBuilder,
 )
@@ -50,58 +51,48 @@ class LocationSensorQuery(QueryBaseModel):
     def where(self):
         return "n.sensor_nodes_id = :locations_id"
 
-class HourlyDataQueries(
-    Paging,
+class BaseDatetimeQueries(
     SensorQuery,
-    DateFromQuery,
-    DateToQuery,
-    BaseDataQuery,
-    PeriodNameQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
 ):
-    ...
-
-class DailyDataQueries(
-    Paging,
-    SensorQuery,
-    DateFromQuery,
-    DateToQuery,
-    BaseDataQuery,
-    PeriodNameQuery,
-):
-    ...
-
-class AnnualDataQueries(
-    Paging,
-    SensorQuery,
-    DateFromQuery,
-    DateToQuery,
-    BaseDataQuery,
-    PeriodNameQuery,
-):
-    ...
-
-
-class SensorMeasurementsQueries(
-    Paging,
-    SensorQuery,
-    DateFromQuery,
-    DateToQuery,
-    BaseDataQuery,
-    PeriodNameQuery,
-):
-    @field_validator('date_to', 'date_from')
+    @model_validator(mode="after")
     @classmethod
-    def must_be_date_if_aggregating_to_day(cls, v: Any, values) -> str:
-        if values.data.get('period_name') in ['dow','day','moy','month','year']:
-            if isinstance(v, datetime):
-                # this is to deal with the error that is thrown when using ValueError with datetime objects
-                err = [{
-                    "type": "value_error",
-                    "msg": "When aggregating data to daily values or higher you can only use whole dates in the `date_from` and `date_to` parameters. E.g. 2024-01-01, 2024-01-01 00:00:00",
-                    "input": str(v)
-                       }]
-                raise HTTPException(status_code=422, detail=err)
-        return v
+    def check_dates_are_in_order(cls, data: Any) -> Any:
+        dt = getattr(data, 'datetime_to')
+        df = getattr(data, 'datetime_from')
+        if dt and df and dt <= df:
+            raise RequestValidationError(
+                f"Date/time from must be older than the date/time to. User passed {df} - {dt}"
+            )
+
+class PagedDatetimeQueries(
+    Paging,
+    BaseDatetimeQueries,
+    ):
+    ...
+
+
+class BaseDateQueries(
+    SensorQuery,
+    DateFromQuery,
+    DateToQuery,
+):
+    @model_validator(mode="after")
+    @classmethod
+    def check_dates_are_in_order(cls, data: Any) -> Any:
+        dt = getattr(data, 'date_to')
+        df = getattr(data, 'date_from')
+        if dt and df and dt <= df:
+            raise RequestValidationError(
+                f"Date from must be older than the date to. User passed {df} - {dt}"
+            )
+
+class PagedDateQueries(
+    Paging,
+    BaseDateQueries,
+    ):
+    ...
 
 
 
@@ -112,7 +103,7 @@ class SensorMeasurementsQueries(
     description="Provides a list of measurements by sensor ID",
 )
 async def sensor_measurements_get(
-    sensors: Annotated[SensorMeasurementsQueries, Depends(SensorMeasurementsQueries.depends())],
+    sensors: Annotated[PagedDatetimeQueries, Depends(PagedDatetimeQueries.depends())],
     db: DB = Depends(),
 ):
     query = QueryBuilder(sensors)
@@ -127,7 +118,7 @@ async def sensor_measurements_get(
     description="Provides a list of measurements by sensor ID",
 )
 async def sensor_measurements_aggregated_get(
-    sensors: Annotated[SensorMeasurementsQueries, Depends(SensorMeasurementsQueries.depends())],
+    sensors: Annotated[PagedDatetimeQueries, Depends(PagedDatetimeQueries.depends())],
     db: DB = Depends(),
 ):
     aggregate_to = 'hour'
@@ -142,7 +133,7 @@ async def sensor_measurements_aggregated_get(
     description="Provides a list of measurements by sensor ID",
 )
 async def sensor_measurements_aggregated_get(
-    sensors: Annotated[SensorMeasurementsQueries, Depends(SensorMeasurementsQueries.depends())],
+    sensors: Annotated[PagedDatetimeQueries, Depends(PagedDatetimeQueries.depends())],
     db: DB = Depends(),
 ):
     aggregate_to = 'day'
@@ -158,7 +149,7 @@ async def sensor_measurements_aggregated_get(
     description="Provides a list of hourly data by sensor ID",
 )
 async def sensor_hourly_measurements_get(
-    sensors: Annotated[HourlyDataQueries, Depends(HourlyDataQueries.depends())],
+    sensors: Annotated[PagedDatetimeQueries, Depends(PagedDatetimeQueries.depends())],
     db: DB = Depends(),
 ):
     query = QueryBuilder(sensors)
@@ -173,10 +164,26 @@ async def sensor_hourly_measurements_get(
     description="Provides a list of daily summaries of hourly data by sensor ID",
 )
 async def sensor_hourly_measurements_aggregate_to_day_get(
-    sensors: Annotated[HourlyDataQueries, Depends(HourlyDataQueries.depends())],
+    sensors: Annotated[PagedDatetimeQueries, Depends(PagedDatetimeQueries.depends())],
     db: DB = Depends(),
 ):
     aggregate_to = 'day'
+    query = QueryBuilder(sensors)
+    response = await fetch_aggregate_hours(query, aggregate_to, db)
+    return response
+
+
+@router.get(
+    "/sensors/{sensors_id}/hours/monthly",
+    response_model=HourlyDataResponse,
+    summary="Get measurements aggregated from hour to month by sensor ID",
+    description="Provides a list of daily summaries of hourly data by sensor ID",
+)
+async def sensor_hourly_measurements_aggregate_to_month_get(
+    sensors: Annotated[PagedDatetimeQueries, Depends(PagedDatetimeQueries.depends())],
+    db: DB = Depends(),
+):
+    aggregate_to = 'month'
     query = QueryBuilder(sensors)
     response = await fetch_aggregate_hours(query, aggregate_to, db)
     return response
@@ -189,12 +196,90 @@ async def sensor_hourly_measurements_aggregate_to_day_get(
     description="Provides a list of yearly summaries of hourly data by sensor ID",
 )
 async def sensor_hourly_measurements_aggregate_to_year_get(
-    sensors: Annotated[HourlyDataQueries, Depends(HourlyDataQueries.depends())],
+    sensors: Annotated[PagedDatetimeQueries, Depends(PagedDatetimeQueries.depends())],
     db: DB = Depends(),
 ):
     aggregate_to = 'year'
     query = QueryBuilder(sensors)
     response = await fetch_aggregate_hours(query, aggregate_to, db)
+    return response
+
+
+@router.get(
+    "/sensors/{sensors_id}/hours/hourofday",
+    response_model=HourlyDataResponse,
+    summary="Get measurements aggregated from hour to day of week by sensor ID",
+    description="Provides a list of yearly summaries of hourly data by sensor ID",
+)
+async def sensor_hourly_measurements_aggregate_to_hod_get(
+    sensors: Annotated[BaseDatetimeQueries, Depends(BaseDatetimeQueries.depends())],
+    db: DB = Depends(),
+):
+    aggregate_to = 'hod'
+    query = QueryBuilder(sensors)
+    response = await fetch_aggregate_trends('hourly_data', aggregate_to, query, db)
+    return response
+
+@router.get(
+    "/sensors/{sensors_id}/hours/dayofweek",
+    response_model=HourlyDataResponse,
+    summary="Get measurements aggregated from hour to day of week by sensor ID",
+    description="Provides a list of yearly summaries of hourly data by sensor ID",
+)
+async def sensor_hourly_measurements_aggregate_to_dow_get(
+    sensors: Annotated[BaseDatetimeQueries, Depends(BaseDatetimeQueries.depends())],
+    db: DB = Depends(),
+):
+    aggregate_to = 'dow'
+    query = QueryBuilder(sensors)
+    response = await fetch_aggregate_trends('hourly_data', aggregate_to, query, db)
+    return response
+
+@router.get(
+    "/sensors/{sensors_id}/hours/monthofyear",
+    response_model=HourlyDataResponse,
+    summary="Get measurements aggregated from hour to day of week by sensor ID",
+    description="Provides a list of yearly summaries of hourly data by sensor ID",
+)
+async def sensor_hourly_measurements_aggregate_to_moy_get(
+    sensors: Annotated[BaseDatetimeQueries, Depends(BaseDatetimeQueries.depends())],
+    db: DB = Depends(),
+):
+    aggregate_to = 'moy'
+    query = QueryBuilder(sensors)
+    response = await fetch_aggregate_trends('hourly_data', aggregate_to, query, db)
+    return response
+
+
+@router.get(
+    "/sensors/{sensors_id}/days/dayofweek",
+    response_model=HourlyDataResponse,
+    summary="Get measurements aggregated from day to day of week by sensor ID",
+    description="Provides a list of yearly summaries of dayly data by sensor ID",
+)
+async def sensor_daily_measurements_aggregate_to_dow_get(
+    sensors: Annotated[BaseDateQueries, Depends(BaseDateQueries.depends())],
+    db: DB = Depends(),
+):
+    aggregate_to = 'dow'
+    query = QueryBuilder(sensors)
+    response = await fetch_aggregate_trends('daily_data', aggregate_to, query, db)
+    return response
+
+
+@router.get(
+    "/sensors/{sensors_id}/days/monthofyear",
+    response_model=HourlyDataResponse,
+    summary="Get measurements aggregated from day to day of week by sensor ID",
+    description="Provides a list of yearly summaries of daily data by sensor ID",
+)
+async def sensor_daily_measurements_aggregate_to_moy_get(
+    sensors: Annotated[BaseDateQueries, Depends(BaseDateQueries.depends())],
+    db: DB = Depends(),
+):
+    aggregate_to = 'moy'
+    query = QueryBuilder(sensors)
+    response = await fetch_aggregate_trends('daily_data', aggregate_to, query, db)
     return response
 
 
@@ -205,12 +290,29 @@ async def sensor_hourly_measurements_aggregate_to_year_get(
     description="Provides a list of daily data by sensor ID",
 )
 async def sensor_daily_get(
-    sensors: Annotated[DailyDataQueries, Depends(DailyDataQueries.depends())],
+    sensors: Annotated[PagedDateQueries, Depends(PagedDateQueries.depends())],
     db: DB = Depends(),
 ):
     query = QueryBuilder(sensors)
     response = await fetch_days(query, db)
     return response
+
+
+@router.get(
+    "/sensors/{sensors_id}/days/monthly",
+    response_model=HourlyDataResponse,
+    summary="Get measurements aggregated from hour to month by sensor ID",
+    description="Provides a list of daily summaries of hourly data by sensor ID",
+)
+async def sensor_daily_aggregate_to_month_get(
+    sensors: Annotated[PagedDateQueries, Depends(PagedDateQueries.depends())],
+    db: DB = Depends(),
+):
+    aggregate_to = 'month'
+    query = QueryBuilder(sensors)
+    response = await fetch_aggregate_days(query, aggregate_to, db)
+    return response
+
 
 @router.get(
     "/sensors/{sensors_id}/days/yearly",
@@ -219,7 +321,7 @@ async def sensor_daily_get(
     description="Provides a list of yearly summaries of daily data by sensor ID",
 )
 async def sensor_daily_aggregate_to_year_get(
-    sensors: Annotated[HourlyDataQueries, Depends(HourlyDataQueries.depends())],
+    sensors: Annotated[PagedDateQueries, Depends(PagedDateQueries.depends())],
     db: DB = Depends(),
 ):
     aggregate_to = 'year'
@@ -236,7 +338,7 @@ async def sensor_daily_aggregate_to_year_get(
     description="Provides a list of annual data by sensor ID",
 )
 async def sensor_yearly_get(
-    sensors: Annotated[AnnualDataQueries, Depends(AnnualDataQueries.depends())],
+    sensors: Annotated[PagedDateQueries, Depends(PagedDateQueries.depends())],
     db: DB = Depends(),
 ):
     query = QueryBuilder(sensors)
@@ -322,28 +424,137 @@ async def fetch_sensors(q, db):
 
 
 
-async def fetch_measurements_old(q, db, base_data = 'measurements'):
-    query = QueryBuilder(q)
 
-    if base_data == 'hourly':
+async def fetch_measurements(query, db):
+    sql = f"""
+      SELECT m.sensors_id
+       , value
+        , get_datetime_object(m.datetime, tz.tzid)
+        , json_build_object(
+            'id', s.measurands_id
+          , 'units', p.units
+          , 'name', p.measurand
+        ) as parameter
+    , json_build_object(
+         'label', 'raw'
+       , 'interval', make_interval(secs=>s.data_logging_period_seconds)
+       , 'datetime_from', get_datetime_object(m.datetime - make_interval(secs=>s.data_logging_period_seconds), tz.tzid)
+       , 'datetime_to', get_datetime_object(m.datetime, tz.tzid)
+      ) as period
+    , json_build_object(
+         'expected_count', 1
+        , 'observed_count', 1
+       , 'expected_interval', make_interval(secs=>s.data_logging_period_seconds)
+       , 'observed_interval', make_interval(secs=>s.data_averaging_period_seconds)
+       , 'datetime_from', get_datetime_object(m.datetime - make_interval(secs=>s.data_averaging_period_seconds), tz.tzid)
+       , 'datetime_to', get_datetime_object(m.datetime, tz.tzid)
+       , 'percent_complete', 100
+       , 'percent_coverage', (s.data_averaging_period_seconds/s.data_logging_period_seconds)*100
+      ) as coverage
+        FROM measurements m
+        JOIN sensors s USING (sensors_id)
+        JOIN measurands p USING (measurands_id)
+        JOIN sensor_systems sy USING (sensor_systems_id)
+        JOIN sensor_nodes sn USING (sensor_nodes_id)
+        JOIN timezones tz USING (timezones_id)
+        {query.where()}
+        ORDER BY datetime
+        {query.pagination()}
+        """
+    return await db.fetchPage(sql, query.params())
+
+
+
+async def fetch_aggregate_measurements(query, aggregate_to, db):
+    if aggregate_to == 'hour':
         dur = "01:00:00"
         expected_hours = 1
-        base_query_name = 'hourly_data'
         interval_seconds = 3600
-    elif base_data == 'daily':
-        base_query_name = 'daily_data'
+    elif aggregate_to == 'day':
+        dur = "24:00:00"
         interval_seconds = 3600 * 24
-    elif base_data == 'yearly':
-        dur = "01:00:00"
-        expected_hours = 1
-        base_query_name = 'yearly_data'
-        interval_seconds = 3600 * 24 * 365.242
-    else: ## raw data
-        base_query_name = 'measurements'
+    else:
+        raise Exception(f'{aggregate_to} is not supported')
 
+    sql = f"""
+        WITH meas AS (
+        SELECT
+        sy.sensor_nodes_id
+        , s.measurands_id
+        , tz.tzid as timezone
+        , truncate_timestamp(datetime, :aggregate_to, tz.tzid) as datetime
+        , AVG(s.data_averaging_period_seconds) as avg_seconds
+        , AVG(s.data_logging_period_seconds) as log_seconds
+        , MAX(truncate_timestamp(datetime, '{aggregate_to}', tz.tzid, '1{aggregate_to}'::interval))
+           as last_period
+        , MIN(timezone(tz.tzid, datetime - '1sec'::interval)) as datetime_first
+        , MAX(timezone(tz.tzid, datetime - '1sec'::interval)) as datetime_last
+        , COUNT(1) as value_count
+        , AVG(value) as value_avg
+        , STDDEV(value) as value_sd
+        , MIN(value) as value_min
+        , MAX(value) as value_max
+        , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value) as value_p02
+        , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value) as value_p25
+        , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value) as value_p50
+        , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value) as value_p75
+        , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value) as value_p98
+        , current_timestamp as calculated_on
+        FROM measurements m
+        JOIN sensors s ON (m.sensors_id = s.sensors_id)
+        JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
+        JOIN sensor_nodes sn ON (sy.sensor_nodes_id = sn.sensor_nodes_id)
+        JOIN timezones tz ON (sn.timezones_id = tz.timezones_id)
+        {query.where()}
+        GROUP BY 1, 2, 3, 4)
+        SELECT t.sensor_nodes_id
+        ----------
+        , json_build_object(
+            'label', '1 {aggregate_to}'
+            , 'datetime_from', get_datetime_object(datetime, t.timezone)
+            , 'datetime_to', get_datetime_object(last_period, t.timezone)
+            , 'interval',  '{dur}'
+            ) as period
+        ----------
+        , sig_digits(value_avg, 2) as value
+        -----------
+        , json_build_object(
+            'id', t.measurands_id
+            , 'units', m.units
+            , 'name', m.measurand
+        ) as parameter
+        ---------
+        , json_build_object(
+             'avg', t.value_avg
+           , 'sd', t.value_sd
+           , 'min', t.value_min
+           , 'q02', t.value_p02
+           , 'q25', t.value_p25
+           , 'median', t.value_p50
+           , 'q75', t.value_p75
+           , 'q98', t.value_p98
+           , 'max', t.value_max
+        ) as summary
+        --------
+        , calculate_coverage(
+            value_count::int
+            , {interval_seconds}
+            , {interval_seconds}
+            , EXTRACT(EPOCH FROM last_period - datetime)
+        )||jsonb_build_object(
+                'datetime_from', get_datetime_object(datetime_first, t.timezone)
+                , 'datetime_to', get_datetime_object(datetime_last, t.timezone)
+                ) as coverage
+        {query.total()}
+        FROM meas t
+        JOIN measurands m ON (t.measurands_id = m.measurands_id)
+        {query.pagination()}
+    """
+    params = query.params()
+    params['aggregate_to'] = aggregate_to
+    return await db.fetchPage(sql, params)
 
-    if q.period_name in [None, "hour"]:
-        # Query for hourly data
+async def fetch_hours(query, db):
         sql = f"""
         SELECT sn.id
         , json_build_object(
@@ -358,7 +569,8 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
         , 'name', m.measurand
         ) as parameter
         , json_build_object(
-          'sd', h.value_sd
+             'avg', h.value_avg
+           , 'sd', h.value_sd
         , 'min', h.value_min
         , 'q02', h.value_p02
         , 'q25', h.value_p25
@@ -372,13 +584,13 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
           h.value_count
         , s.data_averaging_period_seconds
         , s.data_logging_period_seconds
-        , {expected_hours} * 3600
+        , 1 * 3600
         )||jsonb_build_object(
-          'datetime_from', get_datetime_object(h.first_datetime, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
+          'datetime_from', get_datetime_object(h.datetime_first, sn.timezone)
+        , 'datetime_to', get_datetime_object(h.datetime_last, sn.timezone)
         ) as coverage
         {query.fields()}
-        FROM {base_query_name} h
+        FROM hourly_data h
         JOIN sensors s USING (sensors_id)
         JOIN sensor_systems sy USING (sensor_systems_id)
         JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
@@ -387,164 +599,151 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
         ORDER BY datetime
         {query.pagination()}
         """
-    elif q.period_name in ["raw"]:
-        sql = f"""
-    WITH sensor AS (
-        SELECT s.sensors_id
-    , sn.sensor_nodes_id
-  , s.data_averaging_period_seconds
-  , s.data_logging_period_seconds
-  , format('%ssec', s.data_averaging_period_seconds)::interval as averaging_interval
-  , format('%ssec', s.data_logging_period_seconds)::interval as logging_interval
-    , tz.tzid as timezone
-    , m.measurands_id
-    , m.measurand
-    , m.unit
-    , as_timestamptz(:date_from, tz.tzid) as datetime_from
-    , as_timestamptz(:date_to, tz.tzid) as datetime_to
-   FROM sensors s
-    , sensor_systems sy
-    , sensor_nodes sn
-    , timezones tz
-    , measurands m
-    WHERE s.sensor_systems_id = sy.sensor_systems_id
-    AND sy.sensor_nodes_id = sn.sensor_nodes_id
-    AND sn.timezones_id = tz.timezones_id
-    AND s.sensors_id = :sensors_id
-    AND s.measurands_id = m.measurands_id
-    AND sn.is_public AND s.is_public)
-      SELECT m.sensors_id
-       , value
-        , get_datetime_object(m.datetime, s.timezone)
+        return await db.fetchPage(sql, query.params())
+
+
+async def fetch_aggregate_hours(query, aggregate_to, db):
+    if aggregate_to == 'year':
+        dur = "1year"
+    elif aggregate_to == 'month':
+        dur = "1month"
+    elif aggregate_to == 'day':
+        dur = "24:00:00"
+    else:
+        raise Exception(f'{aggregate_to} is not supported')
+
+    query.set_column_map({ "timezone": "tz.tzid" })
+
+    sql = f"""
+        WITH meas AS (
+        SELECT
+        sy.sensor_nodes_id
+        , s.measurands_id
+        , tz.tzid as timezone
+        , truncate_timestamp(datetime, :aggregate_to, tz.tzid) as datetime
+        , AVG(s.data_averaging_period_seconds) as avg_seconds
+        , AVG(s.data_logging_period_seconds) as log_seconds
+        , MAX(truncate_timestamp(datetime, '{aggregate_to}', tz.tzid, '{dur}'::interval))
+           as last_period
+        , MIN(timezone(tz.tzid, datetime - '1sec'::interval)) as datetime_first
+        , MAX(timezone(tz.tzid, datetime - '1sec'::interval)) as datetime_last
+        , COUNT(1) as value_count
+        , AVG(value_avg) as value_avg
+        , STDDEV(value_avg) as value_sd
+        , MIN(value_avg) as value_min
+        , MAX(value_avg) as value_max
+        , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value_avg) as value_p02
+        , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value_avg) as value_p25
+        , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value_avg) as value_p50
+        , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
+        , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
+        , current_timestamp as calculated_on
+        FROM hourly_data m
+        JOIN sensors s ON (m.sensors_id = s.sensors_id)
+        JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
+        JOIN sensor_nodes sn ON (sy.sensor_nodes_id = sn.sensor_nodes_id)
+        JOIN timezones tz ON (sn.timezones_id = tz.timezones_id)
+        {query.where()}
+        GROUP BY 1, 2, 3, 4)
+        SELECT t.sensor_nodes_id
+        ----------
         , json_build_object(
-            'id', s.measurands_id
-          , 'units', s.units
-          , 'name', s.measurand
+            'label', '1 {aggregate_to}'
+            , 'datetime_from', get_datetime_object(datetime, t.timezone)
+            , 'datetime_to', get_datetime_object(last_period, t.timezone)
+            , 'interval',  '{dur}'
+            ) as period
+        ----------
+        , sig_digits(value_avg, 2) as value
+        -----------
+        , json_build_object(
+            'id', t.measurands_id
+            , 'units', m.units
+            , 'name', m.measurand
         ) as parameter
-    , json_build_object(
-         'label', 'raw'
-       , 'interval', s.logging_interval
-       , 'datetime_from', get_datetime_object(m.datetime - s.logging_interval, s.timezone)
-       , 'datetime_to', get_datetime_object(m.datetime, s.timezone)
-      ) as period
-    , json_build_object(
-         'expected_count', 1
-        , 'observed_count', 1
-       , 'expected_interval', s.logging_interval
-       , 'observed_interval', s.averaging_interval
-       , 'datetime_from', get_datetime_object(m.datetime - s.averaging_interval, s.timezone)
-       , 'datetime_to', get_datetime_object(m.datetime, s.timezone)
-       , 'percent_complete', 100
-       , 'percent_coverage', (s.data_averaging_period_seconds/s.data_logging_period_seconds)*100
-      ) as coverage
-        FROM measurements m
-        JOIN sensor s USING (sensors_id)
-        WHERE datetime > datetime_from
-              AND datetime <= datetime_to
-              AND s.sensors_id = :sensors_id
-        ORDER BY datetime
+        ---------
+        , json_build_object(
+             'avg', t.value_avg
+           , 'sd', t.value_sd
+           , 'min', t.value_min
+           , 'q02', t.value_p02
+           , 'q25', t.value_p25
+           , 'median', t.value_p50
+           , 'q75', t.value_p75
+           , 'q98', t.value_p98
+           , 'max', t.value_max
+        ) as summary
+        --------
+        , calculate_coverage(
+            value_count::int
+            , 3600
+            , 3600
+            , EXTRACT(EPOCH FROM last_period - datetime)
+        )||jsonb_build_object(
+                'datetime_from', get_datetime_object(datetime_first, t.timezone)
+                , 'datetime_to', get_datetime_object(datetime_last, t.timezone)
+                ) as coverage
+        {query.total()}
+        FROM meas t
+        JOIN measurands m ON (t.measurands_id = m.measurands_id)
         {query.pagination()}
-              """
-    elif q.period_name in ["day", "month", "year"]:
-        # Query for the aggregate data
-        if q.period_name == "day":
-            dur = "24:00:00"
-        elif q.period_name == "month":
-            dur = "1month"
-        elif q.period_name == "year":
-            dur = "1year"
+    """
+    params = query.params()
+    params['aggregate_to'] = aggregate_to
+    return await db.fetchPage(sql, params)
 
 
-        sql = f"""
-            WITH meas AS (
-            SELECT
-            sy.sensor_nodes_id
-            , s.measurands_id
-            , sn.timezone
-            , truncate_timestamp(datetime, :period_name, sn.timezone) as datetime
-            , AVG(s.data_averaging_period_seconds) as avg_seconds
-            , AVG(s.data_logging_period_seconds) as log_seconds
-            , MAX(truncate_timestamp(datetime, :period_name, sn.timezone, '1{q.period_name}'::interval)) as last_period
-            , MIN(timezone(sn.timezone, datetime - '1sec'::interval)) as first_datetime
-            , MAX(timezone(sn.timezone, datetime - '1sec'::interval)) as last_datetime
-            , COUNT(1) as value_count
-            , AVG(value_avg) as value_avg
-            , STDDEV(value_avg) as value_sd
-            , MIN(value_avg) as value_min
-            , MAX(value_avg) as value_max
-            , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value_avg) as value_p02
-            , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value_avg) as value_p25
-            , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value_avg) as value_p50
-            , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
-            , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
-            , current_timestamp as calculated_on
-            FROM {base_query_name} m
-            JOIN sensors s ON (m.sensors_id = s.sensors_id)
-            JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
-            JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-            {query.where()}
-            GROUP BY 1, 2, 3, 4)
-            SELECT t.sensor_nodes_id
-            ----------
-            , json_build_object(
-                'label', '1 {q.period_name}'
-                , 'datetime_from', get_datetime_object(datetime, t.timezone)
-                , 'datetime_to', get_datetime_object(last_period, t.timezone)
-                , 'interval',  '{dur}'
-                ) as period
-            ----------
-            , sig_digits(value_avg, 2) as value
-            -----------
-            , json_build_object(
-                'id', t.measurands_id
-                , 'units', m.units
-                , 'name', m.measurand
-            ) as parameter
-            ---------
-            , json_build_object(
-                'sd', t.value_sd
-               , 'min', t.value_min
-               , 'q02', t.value_p02
-               , 'q25', t.value_p25
-               , 'median', t.value_p50
-               , 'q75', t.value_p75
-               , 'q98', t.value_p98
-               , 'max', t.value_max
-            ) as summary
-            --------
-            , calculate_coverage(
-                value_count::int
-                , {interval_seconds}
-                , {interval_seconds}
-                , EXTRACT(EPOCH FROM last_period - datetime)
-            )||jsonb_build_object(
-                    'datetime_from', get_datetime_object(first_datetime, t.timezone)
-                    , 'datetime_to', get_datetime_object(last_datetime, t.timezone)
-                    ) as coverage
-            {query.total()}
-            FROM meas t
-            JOIN measurands m ON (t.measurands_id = m.measurands_id)
-            {query.pagination()}
-        """
-    elif q.period_name in ["hod","dow","moy"]:
-        if q.period_name == "hod":
-            q.period_name = "hour"
-            period_format = "'HH24'"
-            period_first_offset = "'-1sec'"
-            period_last_offset = "'+1sec'"
-        elif q.period_name == "dow":
-            q.period_name = "day"
-            period_format = "'ID'"
-            period_first_offset = "'0sec'"
-            period_last_offset = "'0sec'"
-        elif q.period_name == "moy":
-            q.period_name = "month"
-            period_format = "'MM'"
-            period_first_offset = "'-1sec'"
-            period_last_offset = "'+1sec'"
+
+async def fetch_aggregate_trends(base_data_table, aggregate_to, query, db):
+
+    if aggregate_to == "hod":
+        period_name = "hour"
+        period_format = "'HH24'"
+        period_first_offset = "'-1sec'"
+        period_last_offset = "'+1sec'"
+        aggregate_to = "hour"
+    elif aggregate_to == "dow":
+        period_name = "day"
+        period_format = "'ID'"
+        period_first_offset = "'0sec'"
+        period_last_offset = "'0sec'"
+        aggregate_to = "day"
+    elif aggregate_to == "moy":
+        period_name = "month"
+        period_format = "'MM'"
+        period_first_offset = "'-1sec'"
+        period_last_offset = "'+1sec'"
+        aggregate_to = "month"
 
 
-        sql = f"""
+    if base_data_table == "hourly_data":
+        dur = "01:00:00"
+    elif base_data_table == "daily_data":
+        dur = "24:00:00"
+
+
+    params = query.params()
+    params['aggregate_to'] = aggregate_to
+
+    if base_data_table in ['hourly_data']:
+        datetime_field_name = 'datetime'
+        if params.get('datetime_to') is None:
+            params['datetime_to'] = date.today()
+
+        if params.get('datetime_from') is None:
+            dt = params.get('datetime_to')
+            params['datetime_from'] = dt - timedelta(days=365)
+    else:
+        datetime_field_name = 'date'
+        if params.get('date_to') is None:
+            params['date_to'] = date.today()
+
+        if params.get('date_from') is None:
+            dt = params.get('date_to')
+            params['date_from'] = dt - timedelta(days=365)
+
+
+    sql = f"""
     -----------------------------------
     -- start by getting some basic sensor information
     -- and transforming the timestamps
@@ -558,8 +757,8 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
         , m.measurands_id
         , m.measurand
         , m.units
-        , as_timestamptz(:date_from, tz.tzid) as datetime_from
-        , as_timestamptz(:date_to, tz.tzid) as datetime_to
+        , as_timestamptz(:{datetime_field_name}_from, tz.tzid) as datetime_from
+        , as_timestamptz(:{datetime_field_name}_to, tz.tzid) as datetime_to
         FROM sensors s
         , sensor_systems sy
         , sensor_nodes sn
@@ -578,8 +777,8 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
         SELECT to_char(timezone(s.timezone, dd - '1sec'::interval), {period_format}) as factor
         , s.timezone
         , COUNT(1) as n
-        , MIN(date_trunc(:period_name, dd + {period_first_offset}::interval)) as period_first
-        , MAX(date_trunc(:period_name, dd + {period_last_offset}::interval)) as period_last
+        , MIN(date_trunc(:aggregate_to, dd + {period_first_offset}::interval)) as period_first
+        , MAX(date_trunc(:aggregate_to, dd + {period_last_offset}::interval)) as period_last
         FROM sensor s
         , generate_series(s.datetime_from + '1hour'::interval, s.datetime_to, ('1hour')::interval) dd
         GROUP BY 1,2
@@ -610,7 +809,7 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
  , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
  , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
  , current_timestamp as calculated_on
- FROM hourly_data m
+ FROM {base_data_table} m
  JOIN sensor s ON (m.sensors_id = s.sensors_id)
  WHERE datetime > datetime_from
  AND datetime <= datetime_to
@@ -627,8 +826,9 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
    , 'name', o.measurand
   ) as parameter
   , json_build_object(
-     'sd', o.value_sd
-   , 'min', o.value_min
+     'avg', o.value_avg
+    , 'sd', o.value_sd
+    , 'min', o.value_min
    , 'q02', o.value_p02
    , 'q25', o.value_p25
    , 'median', o.value_p50
@@ -640,7 +840,7 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
        'label', e.factor
      , 'datetime_from', get_datetime_object(e.period_first, o.timezone)
      , 'datetime_to', get_datetime_object(e.period_last, o.timezone)
-     , 'interval', :period_name
+     , 'interval', :aggregate_to
     ) as period
     , calculate_coverage(
         o.n::int
@@ -653,300 +853,18 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
     ) as coverage
     FROM expected e
     JOIN observed o ON (e.factor = o.factor)
-    {query.pagination()}
     """
 
-    return await db.fetchPage(sql, query.params())
-
-
-
-async def fetch_measurements(query, db):
-    sql = f"""
-    WITH sensor AS (
-        SELECT s.sensors_id
-    , sn.sensor_nodes_id
-  , s.data_averaging_period_seconds
-  , s.data_logging_period_seconds
-  , format('%ssec', s.data_averaging_period_seconds)::interval as averaging_interval
-  , format('%ssec', s.data_logging_period_seconds)::interval as logging_interval
-    , tz.tzid as timezone
-    , m.measurands_id
-    , m.measurand
-    , m.units
-    , as_timestamptz(:date_from, tz.tzid) as datetime_from
-    , as_timestamptz(:date_to, tz.tzid) as datetime_to
-   FROM sensors s
-    , sensor_systems sy
-    , sensor_nodes sn
-    , timezones tz
-    , measurands m
-    WHERE s.sensor_systems_id = sy.sensor_systems_id
-    AND sy.sensor_nodes_id = sn.sensor_nodes_id
-    AND sn.timezones_id = tz.timezones_id
-    AND s.sensors_id = :sensors_id
-    AND s.measurands_id = m.measurands_id
-    AND sn.is_public AND s.is_public)
-      SELECT m.sensors_id
-       , value
-        , get_datetime_object(m.datetime, s.timezone)
-        , json_build_object(
-            'id', s.measurands_id
-          , 'units', s.units
-          , 'name', s.measurand
-        ) as parameter
-    , json_build_object(
-         'label', 'raw'
-       , 'interval', s.logging_interval
-       , 'datetime_from', get_datetime_object(m.datetime - s.logging_interval, s.timezone)
-       , 'datetime_to', get_datetime_object(m.datetime, s.timezone)
-      ) as period
-    , json_build_object(
-         'expected_count', 1
-        , 'observed_count', 1
-       , 'expected_interval', s.logging_interval
-       , 'observed_interval', s.averaging_interval
-       , 'datetime_from', get_datetime_object(m.datetime - s.averaging_interval, s.timezone)
-       , 'datetime_to', get_datetime_object(m.datetime, s.timezone)
-       , 'percent_complete', 100
-       , 'percent_coverage', (s.data_averaging_period_seconds/s.data_logging_period_seconds)*100
-      ) as coverage
-        FROM measurements m
-        JOIN sensor s USING (sensors_id)
-        WHERE datetime > datetime_from
-              AND datetime <= datetime_to
-              AND s.sensors_id = :sensors_id
-        ORDER BY datetime
-        {query.pagination()}
-        """
-    return await db.fetchPage(sql, query.params())
-
-
-
-async def fetch_aggregate_measurements(query, aggregate_to, db):
-    if aggregate_to == 'hour':
-        dur = "01:00:00"
-        expected_hours = 1
-        interval_seconds = 3600
-    elif aggregate_to == 'day':
-        dur = "24:00:00"
-        interval_seconds = 3600 * 24
-    else:
-        raise Exception(f'{aggregate_to} is not supported')
-
-    sql = f"""
-        WITH meas AS (
-        SELECT
-        sy.sensor_nodes_id
-        , s.measurands_id
-        , sn.timezone
-        , truncate_timestamp(datetime, :period_name, sn.timezone) as datetime
-        , AVG(s.data_averaging_period_seconds) as avg_seconds
-        , AVG(s.data_logging_period_seconds) as log_seconds
-        , MAX(truncate_timestamp(datetime, '{aggregate_to}', sn.timezone, '1{aggregate_to}'::interval))
-           as last_period
-        , MIN(timezone(sn.timezone, datetime - '1sec'::interval)) as first_datetime
-        , MAX(timezone(sn.timezone, datetime - '1sec'::interval)) as last_datetime
-        , COUNT(1) as value_count
-        , AVG(value) as value
-        , STDDEV(value) as value_sd
-        , MIN(value) as value_min
-        , MAX(value) as value_max
-        , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value) as value_p02
-        , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value) as value_p25
-        , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value) as value_p50
-        , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value) as value_p75
-        , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value) as value_p98
-        , current_timestamp as calculated_on
-        FROM measurements m
-        JOIN sensors s ON (m.sensors_id = s.sensors_id)
-        JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        {query.where()}
-        GROUP BY 1, 2, 3, 4)
-        SELECT t.sensor_nodes_id
-        ----------
-        , json_build_object(
-            'label', '1 {aggregate_to}'
-            , 'datetime_from', get_datetime_object(datetime, t.timezone)
-            , 'datetime_to', get_datetime_object(last_period, t.timezone)
-            , 'interval',  '{dur}'
-            ) as period
-        ----------
-        , sig_digits(value, 2) as value
-        -----------
-        , json_build_object(
-            'id', t.measurands_id
-            , 'units', m.units
-            , 'name', m.measurand
-        ) as parameter
-        ---------
-        , json_build_object(
-            'sd', t.value_sd
-           , 'min', t.value_min
-           , 'q02', t.value_p02
-           , 'q25', t.value_p25
-           , 'median', t.value_p50
-           , 'q75', t.value_p75
-           , 'q98', t.value_p98
-           , 'max', t.value_max
-        ) as summary
-        --------
-        , calculate_coverage(
-            value_count::int
-            , {interval_seconds}
-            , {interval_seconds}
-            , EXTRACT(EPOCH FROM last_period - datetime)
-        )||jsonb_build_object(
-                'datetime_from', get_datetime_object(first_datetime, t.timezone)
-                , 'datetime_to', get_datetime_object(last_datetime, t.timezone)
-                ) as coverage
-        {query.total()}
-        FROM meas t
-        JOIN measurands m ON (t.measurands_id = m.measurands_id)
-        {query.pagination()}
-    """
-    params = query.params()
-    return await db.fetchPage(sql, query.params())
-
-async def fetch_hours(query, db):
-        sql = f"""
-        SELECT sn.id
-        , json_build_object(
-        'label', '1hour'
-        , 'datetime_from', get_datetime_object(h.datetime - '1hour'::interval, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.datetime, sn.timezone)
-        , 'interval',  '01:00:00'
-        ) as period
-        , json_build_object(
-        'id', s.measurands_id
-        , 'units', m.units
-        , 'name', m.measurand
-        ) as parameter
-        , json_build_object(
-          'sd', h.value_sd
-        , 'min', h.value_min
-        , 'q02', h.value_p02
-        , 'q25', h.value_p25
-        , 'median', h.value_p50
-        , 'q75', h.value_p75
-        , 'q98', h.value_p98
-        , 'max', h.value_max
-        ) as summary
-        , sig_digits(h.value_avg, 2) as value
-        , calculate_coverage(
-          h.value_count
-        , s.data_averaging_period_seconds
-        , s.data_logging_period_seconds
-        , 1 * 3600
-        )||jsonb_build_object(
-          'datetime_from', get_datetime_object(h.first_datetime, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
-        ) as coverage
-        {query.fields()}
-        FROM hourly_data h
-        JOIN sensors s USING (sensors_id)
-        JOIN sensor_systems sy USING (sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        JOIN measurands m ON (m.measurands_id = s.measurands_id)
-        {query.where()}
-        ORDER BY datetime
-        {query.pagination()}
-        """
-        return await db.fetchPage(sql, query.params())
-
-
-async def fetch_aggregate_hours(query, aggregate_to, db):
-    if aggregate_to == 'year':
-        dur = "1year"
-        expected_hours = 24 * 365.24
-        interval_seconds = 3600 * 24 * 365.24
-    elif aggregate_to == 'day':
-        dur = "24:00:00"
-        interval_seconds = 3600 * 24
-    else:
-        raise Exception(f'{aggregate_to} is not supported')
-
-    sql = f"""
-        WITH meas AS (
-        SELECT
-        sy.sensor_nodes_id
-        , s.measurands_id
-        , sn.timezone
-        , truncate_timestamp(datetime, :period_name, sn.timezone) as datetime
-        , AVG(s.data_averaging_period_seconds) as avg_seconds
-        , AVG(s.data_logging_period_seconds) as log_seconds
-        , MAX(truncate_timestamp(datetime, '{aggregate_to}', sn.timezone, '1{aggregate_to}'::interval))
-           as last_period
-        , MIN(timezone(sn.timezone, datetime - '1sec'::interval)) as first_datetime
-        , MAX(timezone(sn.timezone, datetime - '1sec'::interval)) as last_datetime
-        , COUNT(1) as value_count
-        , AVG(value_avg) as value_avg
-        , STDDEV(value_avg) as value_sd
-        , MIN(value_avg) as value_min
-        , MAX(value_avg) as value_max
-        , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value_avg) as value_p02
-        , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value_avg) as value_p25
-        , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value_avg) as value_p50
-        , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
-        , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
-        , current_timestamp as calculated_on
-        FROM hourly_data m
-        JOIN sensors s ON (m.sensors_id = s.sensors_id)
-        JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        {query.where()}
-        GROUP BY 1, 2, 3, 4)
-        SELECT t.sensor_nodes_id
-        ----------
-        , json_build_object(
-            'label', '1 {aggregate_to}'
-            , 'datetime_from', get_datetime_object(datetime, t.timezone)
-            , 'datetime_to', get_datetime_object(last_period, t.timezone)
-            , 'interval',  '{dur}'
-            ) as period
-        ----------
-        , sig_digits(value_avg, 2) as value
-        -----------
-        , json_build_object(
-            'id', t.measurands_id
-            , 'units', m.units
-            , 'name', m.measurand
-        ) as parameter
-        ---------
-        , json_build_object(
-            'sd', t.value_sd
-           , 'min', t.value_min
-           , 'q02', t.value_p02
-           , 'q25', t.value_p25
-           , 'median', t.value_p50
-           , 'q75', t.value_p75
-           , 'q98', t.value_p98
-           , 'max', t.value_max
-        ) as summary
-        --------
-        , calculate_coverage(
-            value_count::int
-            , {interval_seconds}
-            , {interval_seconds}
-            , EXTRACT(EPOCH FROM last_period - datetime)
-        )||jsonb_build_object(
-                'datetime_from', get_datetime_object(first_datetime, t.timezone)
-                , 'datetime_to', get_datetime_object(last_datetime, t.timezone)
-                ) as coverage
-        {query.total()}
-        FROM meas t
-        JOIN measurands m ON (t.measurands_id = m.measurands_id)
-        {query.pagination()}
-    """
-    params = query.params()
-    return await db.fetchPage(sql, query.params())
+    return await db.fetchPage(sql, params)
 
 
 async def fetch_aggregate_days(query, aggregate_to, db):
     if aggregate_to == 'year':
         dur = "1year"
-        expected_hours = 24 * 365.24
         interval_seconds = 3600 * 24 * 365.24
+    elif aggregate_to == 'month':
+        dur = "1 month"
+        interval_seconds = 3600 * 24
     else:
         raise Exception(f'{aggregate_to} is not supported')
 
@@ -956,13 +874,13 @@ async def fetch_aggregate_days(query, aggregate_to, db):
         sy.sensor_nodes_id
         , s.measurands_id
         , sn.timezone
-        , truncate_timestamp(datetime, :period_name, sn.timezone) as datetime
+        -- days are time begining
+        , date_trunc(:aggregate_to, datetime) as datetime
         , AVG(s.data_averaging_period_seconds) as avg_seconds
         , AVG(s.data_logging_period_seconds) as log_seconds
-        , MAX(truncate_timestamp(datetime, '{aggregate_to}', sn.timezone, '1{aggregate_to}'::interval))
-           as last_period
-        , MIN(timezone(sn.timezone, datetime - '1sec'::interval)) as first_datetime
-        , MAX(timezone(sn.timezone, datetime - '1sec'::interval)) as last_datetime
+        , MAX(date_trunc(:aggregate_to, datetime + '1{aggregate_to}'::interval)) as last_period
+        , MIN(timezone(sn.timezone, datetime - '1sec'::interval)) as datetime_first
+        , MAX(timezone(sn.timezone, datetime - '1sec'::interval)) as datetime_last
         , COUNT(1) as value_count
         , AVG(value_avg) as value_avg
         , STDDEV(value_avg) as value_sd
@@ -974,7 +892,7 @@ async def fetch_aggregate_days(query, aggregate_to, db):
         , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
         , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
         , current_timestamp as calculated_on
-        FROM hourly_data m
+        FROM daily_data m
         JOIN sensors s ON (m.sensors_id = s.sensors_id)
         JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
         JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
@@ -998,7 +916,8 @@ async def fetch_aggregate_days(query, aggregate_to, db):
         ) as parameter
         ---------
         , json_build_object(
-            'sd', t.value_sd
+             'avg', t.value_avg
+           , 'sd', t.value_sd
            , 'min', t.value_min
            , 'q02', t.value_p02
            , 'q25', t.value_p25
@@ -1010,12 +929,12 @@ async def fetch_aggregate_days(query, aggregate_to, db):
         --------
         , calculate_coverage(
             value_count::int
-            , {interval_seconds}
-            , {interval_seconds}
+            , 3600 * 24
+            , 3600 * 24
             , EXTRACT(EPOCH FROM last_period - datetime)
         )||jsonb_build_object(
-                'datetime_from', get_datetime_object(first_datetime, t.timezone)
-                , 'datetime_to', get_datetime_object(last_datetime, t.timezone)
+                'datetime_from', get_datetime_object(datetime_first, t.timezone)
+                , 'datetime_to', get_datetime_object(datetime_last, t.timezone)
                 ) as coverage
         {query.total()}
         FROM meas t
@@ -1023,7 +942,8 @@ async def fetch_aggregate_days(query, aggregate_to, db):
         {query.pagination()}
     """
     params = query.params()
-    return await db.fetchPage(sql, query.params())
+    params['aggregate_to'] = aggregate_to
+    return await db.fetchPage(sql, params)
 
 
 async def fetch_days(query, db):
@@ -1041,7 +961,8 @@ async def fetch_days(query, db):
         , 'name', m.measurand
         ) as parameter
         , json_build_object(
-          'sd', h.value_sd
+             'avg', h.value_avg
+           , 'sd', h.value_sd
         , 'min', h.value_min
         , 'q02', h.value_p02
         , 'q25', h.value_p25
@@ -1053,12 +974,12 @@ async def fetch_days(query, db):
         , sig_digits(h.value_avg, 2) as value
         , calculate_coverage(
           h.value_count
-        , s.data_averaging_period_seconds
-        , s.data_logging_period_seconds
+        , 3600
+        , 3600
         , 24 * 3600
         )||jsonb_build_object(
-          'datetime_from', get_datetime_object(h.first_datetime, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
+          'datetime_from', get_datetime_object(h.datetime_first, sn.timezone)
+        , 'datetime_to', get_datetime_object(h.datetime_last, sn.timezone)
         ) as coverage
         {query.fields()}
         FROM daily_data h
@@ -1092,7 +1013,8 @@ async def fetch_years(query, db):
         , 'name', m.measurand
         ) as parameter
         , json_build_object(
-          'sd', h.value_sd
+             'avg', h.value_avg
+           , 'sd', h.value_sd
         , 'min', h.value_min
         , 'q02', h.value_p02
         , 'q25', h.value_p25
@@ -1104,15 +1026,15 @@ async def fetch_years(query, db):
         , sig_digits(h.value_avg, 2) as value
         , calculate_coverage(
           h.value_count
-        , s.data_averaging_period_seconds
-        , s.data_logging_period_seconds
-        , 3600 * 24 * 365.24
+        , 3600
+        , 3600
+        , 3600 * 24 * ((h.datetime + '1year'::interval)::date - h.datetime)
         )||jsonb_build_object(
-          'datetime_from', get_datetime_object(h.first_datetime, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
+          'datetime_from', get_datetime_object(h.datetime_first, sn.timezone)
+        , 'datetime_to', get_datetime_object(h.datetime_last, sn.timezone)
         ) as coverage
         {query.fields()}
-        FROM yearly_data h
+        FROM annual_data h
         JOIN sensors s USING (sensors_id)
         JOIN sensor_systems sy USING (sensor_systems_id)
         JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
@@ -1122,7 +1044,3 @@ async def fetch_years(query, db):
         {query.pagination()}
         """
         return await db.fetchPage(sql, query.params())
-
-
-def aggregate_years(query, aggregate_to, db):
-    ...

--- a/openaq_api/openaq_api/v3/routers/sensors.py
+++ b/openaq_api/openaq_api/v3/routers/sensors.py
@@ -11,7 +11,6 @@ from openaq_api.v3.models.queries import (
     DateToQuery,
     Paging,
     PeriodNameQuery,
-    BaseDataQuery,
     QueryBaseModel,
     QueryBuilder,
 )
@@ -19,10 +18,7 @@ from openaq_api.v3.models.queries import (
 from openaq_api.v3.models.responses import (
     SensorsResponse,
     MeasurementsResponse,
-    HourlyDataResponse,
-    DailyDataResponse,
-    AnnualDataResponse,
-    )
+)
 
 logger = logging.getLogger("sensors")
 
@@ -50,59 +46,29 @@ class LocationSensorQuery(QueryBaseModel):
     def where(self):
         return "n.sensor_nodes_id = :locations_id"
 
-class HourlyDataQueries(
-    Paging,
-    SensorQuery,
-    DateFromQuery,
-    DateToQuery,
-    BaseDataQuery,
-    PeriodNameQuery,
-):
-    ...
-
-class DailyDataQueries(
-    Paging,
-    SensorQuery,
-    DateFromQuery,
-    DateToQuery,
-    BaseDataQuery,
-    PeriodNameQuery,
-):
-    ...
-
-class AnnualDataQueries(
-    Paging,
-    SensorQuery,
-    DateFromQuery,
-    DateToQuery,
-    BaseDataQuery,
-    PeriodNameQuery,
-):
-    ...
-
 
 class SensorMeasurementsQueries(
     Paging,
     SensorQuery,
     DateFromQuery,
     DateToQuery,
-    BaseDataQuery,
     PeriodNameQuery,
 ):
-    @field_validator('date_to', 'date_from')
+    @field_validator("date_to", "date_from")
     @classmethod
     def must_be_date_if_aggregating_to_day(cls, v: Any, values) -> str:
-        if values.data.get('period_name') in ['dow','day','moy','month','year']:
+        if values.data.get("period_name") in ["dow", "day", "moy", "month"]:
             if isinstance(v, datetime):
                 # this is to deal with the error that is thrown when using ValueError with datetime objects
-                err = [{
-                    "type": "value_error",
-                    "msg": "When aggregating data to daily values or higher you can only use whole dates in the `date_from` and `date_to` parameters. E.g. 2024-01-01, 2024-01-01 00:00:00",
-                    "input": str(v)
-                       }]
+                err = [
+                    {
+                        "type": "value_error",
+                        "msg": "When aggregating data to daily values or higher you can only use whole dates in the `date_from` and `date_to` parameters. E.g. 2024-01-01, 2024-01-01 00:00:00",
+                        "input": str(v),
+                    }
+                ]
                 raise HTTPException(status_code=422, detail=err)
         return v
-
 
 
 @router.get(
@@ -112,139 +78,13 @@ class SensorMeasurementsQueries(
     description="Provides a list of measurements by sensor ID",
 )
 async def sensor_measurements_get(
-    sensors: Annotated[SensorMeasurementsQueries, Depends(SensorMeasurementsQueries.depends())],
+    sensors: Annotated[
+        SensorMeasurementsQueries, Depends(SensorMeasurementsQueries.depends())
+    ],
     db: DB = Depends(),
 ):
-    query = QueryBuilder(sensors)
-    response = await fetch_measurements(query, db)
+    response = await fetch_measurements(sensors, db)
     return response
-
-
-@router.get(
-    "/sensors/{sensors_id}/measurements/hourly",
-    response_model=MeasurementsResponse,
-    summary="Get measurements aggregated to hours by sensor ID",
-    description="Provides a list of measurements by sensor ID",
-)
-async def sensor_measurements_aggregated_get(
-    sensors: Annotated[SensorMeasurementsQueries, Depends(SensorMeasurementsQueries.depends())],
-    db: DB = Depends(),
-):
-    aggregate_to = 'hour'
-    query = QueryBuilder(sensors)
-    response = await fetch_aggregate_measurements(query, aggregate_to, db)
-    return response
-
-@router.get(
-    "/sensors/{sensors_id}/measurements/daily",
-    response_model=MeasurementsResponse,
-    summary="Get measurements aggregated to days by sensor ID",
-    description="Provides a list of measurements by sensor ID",
-)
-async def sensor_measurements_aggregated_get(
-    sensors: Annotated[SensorMeasurementsQueries, Depends(SensorMeasurementsQueries.depends())],
-    db: DB = Depends(),
-):
-    aggregate_to = 'day'
-    query = QueryBuilder(sensors)
-    response = await fetch_aggregate_measurements(query, aggregate_to, db)
-    return response
-
-
-@router.get(
-    "/sensors/{sensors_id}/hours",
-    response_model=HourlyDataResponse,
-    summary="Get measurements aggregated to hour by sensor ID",
-    description="Provides a list of hourly data by sensor ID",
-)
-async def sensor_hourly_measurements_get(
-    sensors: Annotated[HourlyDataQueries, Depends(HourlyDataQueries.depends())],
-    db: DB = Depends(),
-):
-    query = QueryBuilder(sensors)
-    response = await fetch_hours(query, db)
-    return response
-
-
-@router.get(
-    "/sensors/{sensors_id}/hours/daily",
-    response_model=HourlyDataResponse,
-    summary="Get measurements aggregated from hour to day by sensor ID",
-    description="Provides a list of daily summaries of hourly data by sensor ID",
-)
-async def sensor_hourly_measurements_aggregate_to_day_get(
-    sensors: Annotated[HourlyDataQueries, Depends(HourlyDataQueries.depends())],
-    db: DB = Depends(),
-):
-    aggregate_to = 'day'
-    query = QueryBuilder(sensors)
-    response = await fetch_aggregate_hours(query, aggregate_to, db)
-    return response
-
-
-@router.get(
-    "/sensors/{sensors_id}/hours/yearly",
-    response_model=HourlyDataResponse,
-    summary="Get measurements aggregated from hour to year by sensor ID",
-    description="Provides a list of yearly summaries of hourly data by sensor ID",
-)
-async def sensor_hourly_measurements_aggregate_to_year_get(
-    sensors: Annotated[HourlyDataQueries, Depends(HourlyDataQueries.depends())],
-    db: DB = Depends(),
-):
-    aggregate_to = 'year'
-    query = QueryBuilder(sensors)
-    response = await fetch_aggregate_hours(query, aggregate_to, db)
-    return response
-
-
-@router.get(
-    "/sensors/{sensors_id}/days",
-    response_model=DailyDataResponse,
-    summary="Get measurements aggregated to day by sensor ID",
-    description="Provides a list of daily data by sensor ID",
-)
-async def sensor_daily_get(
-    sensors: Annotated[DailyDataQueries, Depends(DailyDataQueries.depends())],
-    db: DB = Depends(),
-):
-    query = QueryBuilder(sensors)
-    response = await fetch_days(query, db)
-    return response
-
-@router.get(
-    "/sensors/{sensors_id}/days/yearly",
-    response_model=HourlyDataResponse,
-    summary="Get measurements aggregated from day to year by sensor ID",
-    description="Provides a list of yearly summaries of daily data by sensor ID",
-)
-async def sensor_daily_aggregate_to_year_get(
-    sensors: Annotated[HourlyDataQueries, Depends(HourlyDataQueries.depends())],
-    db: DB = Depends(),
-):
-    aggregate_to = 'year'
-    query = QueryBuilder(sensors)
-    response = await fetch_aggregate_days(query, aggregate_to, db)
-    return response
-
-
-
-@router.get(
-    "/sensors/{sensors_id}/years",
-    response_model=AnnualDataResponse,
-    summary="Get measurements aggregated to year by sensor ID",
-    description="Provides a list of annual data by sensor ID",
-)
-async def sensor_yearly_get(
-    sensors: Annotated[AnnualDataQueries, Depends(AnnualDataQueries.depends())],
-    db: DB = Depends(),
-):
-    query = QueryBuilder(sensors)
-    response = await fetch_years(query, db)
-    return response
-
-
-
 
 
 @router.get(
@@ -254,7 +94,9 @@ async def sensor_yearly_get(
     description="Provides a list of sensors by location ID",
 )
 async def sensors_get(
-    location_sensors: Annotated[LocationSensorQuery, Depends(LocationSensorQuery.depends())],
+    location_sensors: Annotated[
+        LocationSensorQuery, Depends(LocationSensorQuery.depends())
+    ],
     db: DB = Depends(),
 ):
     return await fetch_sensors(location_sensors, db)
@@ -321,26 +163,10 @@ async def fetch_sensors(q, db):
     return await db.fetchPage(sql, query.params())
 
 
-
-async def fetch_measurements_old(q, db, base_data = 'measurements'):
+async def fetch_measurements(q, db):
     query = QueryBuilder(q)
-
-    if base_data == 'hourly':
-        dur = "01:00:00"
-        expected_hours = 1
-        base_query_name = 'hourly_data'
-        interval_seconds = 3600
-    elif base_data == 'daily':
-        base_query_name = 'daily_data'
-        interval_seconds = 3600 * 24
-    elif base_data == 'yearly':
-        dur = "01:00:00"
-        expected_hours = 1
-        base_query_name = 'yearly_data'
-        interval_seconds = 3600 * 24 * 365.242
-    else: ## raw data
-        base_query_name = 'measurements'
-
+    dur = "01:00:00"
+    expected_hours = 1
 
     if q.period_name in [None, "hour"]:
         # Query for hourly data
@@ -353,9 +179,10 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
         , 'interval',  '01:00:00'
         ) as period
         , json_build_object(
-        'id', s.measurands_id
+        'id', h.measurands_id
         , 'units', m.units
         , 'name', m.measurand
+        , 'display_name', m.display
         ) as parameter
         , json_build_object(
           'sd', h.value_sd
@@ -378,11 +205,11 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
         , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
         ) as coverage
         {query.fields()}
-        FROM {base_query_name} h
+        FROM hourly_data h
         JOIN sensors s USING (sensors_id)
         JOIN sensor_systems sy USING (sensor_systems_id)
         JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        JOIN measurands m ON (m.measurands_id = s.measurands_id)
+        JOIN measurands m ON (m.measurands_id = h.measurands_id)
         {query.where()}
         ORDER BY datetime
         {query.pagination()}
@@ -409,7 +236,7 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
     , measurands m
     WHERE s.sensor_systems_id = sy.sensor_systems_id
     AND sy.sensor_nodes_id = sn.sensor_nodes_id
-    AND sn.timezones_id = tz.timezones_id
+    AND sn.timezones_id = tz.gid
     AND s.sensors_id = :sensors_id
     AND s.measurands_id = m.measurands_id
     AND sn.is_public AND s.is_public)
@@ -445,15 +272,12 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
         ORDER BY datetime
         {query.pagination()}
               """
-    elif q.period_name in ["day", "month", "year"]:
+    elif q.period_name in ["day", "month"]:
         # Query for the aggregate data
         if q.period_name == "day":
             dur = "24:00:00"
         elif q.period_name == "month":
-            dur = "1month"
-        elif q.period_name == "year":
-            dur = "1year"
-
+            dur = "1 month"
 
         sql = f"""
             WITH meas AS (
@@ -478,7 +302,7 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
             , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
             , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
             , current_timestamp as calculated_on
-            FROM {base_query_name} m
+            FROM hourly_data m
             JOIN sensors s ON (m.sensors_id = s.sensors_id)
             JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
             JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
@@ -487,7 +311,7 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
             SELECT t.sensor_nodes_id
             ----------
             , json_build_object(
-                'label', '1 {q.period_name}'
+                'label', '1{q.period_name}'
                 , 'datetime_from', get_datetime_object(datetime, t.timezone)
                 , 'datetime_to', get_datetime_object(last_period, t.timezone)
                 , 'interval',  '{dur}'
@@ -514,8 +338,8 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
             --------
             , calculate_coverage(
                 value_count::int
-                , {interval_seconds}
-                , {interval_seconds}
+                , 3600
+                , 3600
                 , EXTRACT(EPOCH FROM last_period - datetime)
             )||jsonb_build_object(
                     'datetime_from', get_datetime_object(first_datetime, t.timezone)
@@ -526,7 +350,7 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
             JOIN measurands m ON (t.measurands_id = m.measurands_id)
             {query.pagination()}
         """
-    elif q.period_name in ["hod","dow","moy"]:
+    elif q.period_name in ["hod", "dow", "moy"]:
         if q.period_name == "hod":
             q.period_name = "hour"
             period_format = "'HH24'"
@@ -542,7 +366,6 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
             period_format = "'MM'"
             period_first_offset = "'-1sec'"
             period_last_offset = "'+1sec'"
-
 
         sql = f"""
     -----------------------------------
@@ -567,7 +390,7 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
         , measurands m
         WHERE s.sensor_systems_id = sy.sensor_systems_id
         AND sy.sensor_nodes_id = sn.sensor_nodes_id
-        AND sn.timezones_id = tz.timezones_id
+        AND sn.timezones_id = tz.gid
         AND s.sensors_id = :sensors_id
         AND s.measurands_id = m.measurands_id
         AND sn.is_public AND s.is_public
@@ -588,541 +411,73 @@ async def fetch_measurements_old(q, db, base_data = 'measurements'):
     -- we join the sensor CTE here so that we have access to the timezone
     ------------------------------------
     ), observed AS (
-        SELECT
+    SELECT
         s.sensors_id
         , s.data_averaging_period_seconds
         , s.data_logging_period_seconds
- , s.timezone
- , s.measurands_id
- , s.measurand
- , s.units
- , to_char(timezone(s.timezone, datetime - '1sec'::interval), {period_format}) as factor
- , MIN(datetime) as coverage_first
- , MAX(datetime) as coverage_last
- , COUNT(1) as n
- , AVG(value_avg) as value_avg
- , STDDEV(value_avg) as value_sd
- , MIN(value_avg) as value_min
- , MAX(value_avg) as value_max
- , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value_avg) as value_p02
- , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value_avg) as value_p25
- , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value_avg) as value_p50
- , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
- , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
- , current_timestamp as calculated_on
- FROM hourly_data m
- JOIN sensor s ON (m.sensors_id = s.sensors_id)
- WHERE datetime > datetime_from
- AND datetime <= datetime_to
- AND s.sensors_id = :sensors_id
- GROUP BY 1, 2, 3, 4, 5, 6, 7, 8)
------------------------------------------
--- And finally we tie it all together
------------------------------------------
-    SELECT o.sensors_id
-  , sig_digits(value_avg, 2) as value
-  , json_build_object(
-     'id', o.measurands_id
-   , 'units', o.units
-   , 'name', o.measurand
-  ) as parameter
-  , json_build_object(
-     'sd', o.value_sd
-   , 'min', o.value_min
-   , 'q02', o.value_p02
-   , 'q25', o.value_p25
-   , 'median', o.value_p50
-   , 'q75', o.value_p75
-   , 'q98', o.value_p98
-   , 'max', o.value_max
-     ) as summary
-    , json_build_object(
-       'label', e.factor
-     , 'datetime_from', get_datetime_object(e.period_first, o.timezone)
-     , 'datetime_to', get_datetime_object(e.period_last, o.timezone)
-     , 'interval', :period_name
-    ) as period
-    , calculate_coverage(
-        o.n::int
-      , o.data_averaging_period_seconds
-      , o.data_logging_period_seconds
-      , e.n * 3600.0)||
-    jsonb_build_object(
-        'datetime_from', get_datetime_object(o.coverage_first, o.timezone)
-      , 'datetime_to', get_datetime_object(o.coverage_last, o.timezone)
-    ) as coverage
-    FROM expected e
-    JOIN observed o ON (e.factor = o.factor)
-    {query.pagination()}
-    """
-
-    return await db.fetchPage(sql, query.params())
-
-
-
-async def fetch_measurements(query, db):
-    sql = f"""
-    WITH sensor AS (
-        SELECT s.sensors_id
-    , sn.sensor_nodes_id
-  , s.data_averaging_period_seconds
-  , s.data_logging_period_seconds
-  , format('%ssec', s.data_averaging_period_seconds)::interval as averaging_interval
-  , format('%ssec', s.data_logging_period_seconds)::interval as logging_interval
-    , tz.tzid as timezone
-    , m.measurands_id
-    , m.measurand
-    , m.units
-    , as_timestamptz(:date_from, tz.tzid) as datetime_from
-    , as_timestamptz(:date_to, tz.tzid) as datetime_to
-   FROM sensors s
-    , sensor_systems sy
-    , sensor_nodes sn
-    , timezones tz
-    , measurands m
-    WHERE s.sensor_systems_id = sy.sensor_systems_id
-    AND sy.sensor_nodes_id = sn.sensor_nodes_id
-    AND sn.timezones_id = tz.timezones_id
+        , s.timezone
+        , s.measurands_id
+        , s.measurand
+        , s.units
+        , to_char(timezone(s.timezone, datetime - '1sec'::interval), {period_format}) as factor
+        , MIN(datetime) as coverage_first
+        , MAX(datetime) as coverage_last
+        , COUNT(1) as n
+        , AVG(value_avg) as value_avg
+        , STDDEV(value_avg) as value_sd
+        , MIN(value_avg) as value_min
+        , MAX(value_avg) as value_max
+        , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value_avg) as value_p02
+        , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value_avg) as value_p25
+        , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value_avg) as value_p50
+        , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
+        , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
+        , current_timestamp as calculated_on
+    FROM hourly_data m
+    JOIN sensor s ON (m.sensors_id = s.sensors_id)
+    WHERE datetime > datetime_from
+    AND datetime <= datetime_to
     AND s.sensors_id = :sensors_id
-    AND s.measurands_id = m.measurands_id
-    AND sn.is_public AND s.is_public)
-      SELECT m.sensors_id
-       , value
-        , get_datetime_object(m.datetime, s.timezone)
-        , json_build_object(
-            'id', s.measurands_id
-          , 'units', s.units
-          , 'name', s.measurand
-        ) as parameter
-    , json_build_object(
-         'label', 'raw'
-       , 'interval', s.logging_interval
-       , 'datetime_from', get_datetime_object(m.datetime - s.logging_interval, s.timezone)
-       , 'datetime_to', get_datetime_object(m.datetime, s.timezone)
-      ) as period
-    , json_build_object(
-         'expected_count', 1
-        , 'observed_count', 1
-       , 'expected_interval', s.logging_interval
-       , 'observed_interval', s.averaging_interval
-       , 'datetime_from', get_datetime_object(m.datetime - s.averaging_interval, s.timezone)
-       , 'datetime_to', get_datetime_object(m.datetime, s.timezone)
-       , 'percent_complete', 100
-       , 'percent_coverage', (s.data_averaging_period_seconds/s.data_logging_period_seconds)*100
-      ) as coverage
-        FROM measurements m
-        JOIN sensor s USING (sensors_id)
-        WHERE datetime > datetime_from
-              AND datetime <= datetime_to
-              AND s.sensors_id = :sensors_id
-        ORDER BY datetime
-        {query.pagination()}
-        """
-    return await db.fetchPage(sql, query.params())
-
-
-
-async def fetch_aggregate_measurements(query, aggregate_to, db):
-    if aggregate_to == 'hour':
-        dur = "01:00:00"
-        expected_hours = 1
-        interval_seconds = 3600
-    elif aggregate_to == 'day':
-        dur = "24:00:00"
-        interval_seconds = 3600 * 24
-    else:
-        raise Exception(f'{aggregate_to} is not supported')
-
-    sql = f"""
-        WITH meas AS (
-        SELECT
-        sy.sensor_nodes_id
-        , s.measurands_id
-        , sn.timezone
-        , truncate_timestamp(datetime, :period_name, sn.timezone) as datetime
-        , AVG(s.data_averaging_period_seconds) as avg_seconds
-        , AVG(s.data_logging_period_seconds) as log_seconds
-        , MAX(truncate_timestamp(datetime, '{aggregate_to}', sn.timezone, '1{aggregate_to}'::interval))
-           as last_period
-        , MIN(timezone(sn.timezone, datetime - '1sec'::interval)) as first_datetime
-        , MAX(timezone(sn.timezone, datetime - '1sec'::interval)) as last_datetime
-        , COUNT(1) as value_count
-        , AVG(value) as value
-        , STDDEV(value) as value_sd
-        , MIN(value) as value_min
-        , MAX(value) as value_max
-        , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value) as value_p02
-        , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value) as value_p25
-        , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value) as value_p50
-        , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value) as value_p75
-        , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value) as value_p98
-        , current_timestamp as calculated_on
-        FROM measurements m
-        JOIN sensors s ON (m.sensors_id = s.sensors_id)
-        JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        {query.where()}
-        GROUP BY 1, 2, 3, 4)
-        SELECT t.sensor_nodes_id
-        ----------
-        , json_build_object(
-            'label', '1 {aggregate_to}'
-            , 'datetime_from', get_datetime_object(datetime, t.timezone)
-            , 'datetime_to', get_datetime_object(last_period, t.timezone)
-            , 'interval',  '{dur}'
-            ) as period
-        ----------
-        , sig_digits(value, 2) as value
-        -----------
-        , json_build_object(
-            'id', t.measurands_id
-            , 'units', m.units
-            , 'name', m.measurand
-        ) as parameter
-        ---------
-        , json_build_object(
-            'sd', t.value_sd
-           , 'min', t.value_min
-           , 'q02', t.value_p02
-           , 'q25', t.value_p25
-           , 'median', t.value_p50
-           , 'q75', t.value_p75
-           , 'q98', t.value_p98
-           , 'max', t.value_max
-        ) as summary
-        --------
-        , calculate_coverage(
-            value_count::int
-            , {interval_seconds}
-            , {interval_seconds}
-            , EXTRACT(EPOCH FROM last_period - datetime)
-        )||jsonb_build_object(
-                'datetime_from', get_datetime_object(first_datetime, t.timezone)
-                , 'datetime_to', get_datetime_object(last_datetime, t.timezone)
-                ) as coverage
-        {query.total()}
-        FROM meas t
-        JOIN measurands m ON (t.measurands_id = m.measurands_id)
-        {query.pagination()}
-    """
-    params = query.params()
-    return await db.fetchPage(sql, query.params())
-
-async def fetch_hours(query, db):
-        sql = f"""
-        SELECT sn.id
-        , json_build_object(
-        'label', '1hour'
-        , 'datetime_from', get_datetime_object(h.datetime - '1hour'::interval, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.datetime, sn.timezone)
-        , 'interval',  '01:00:00'
-        ) as period
-        , json_build_object(
-        'id', s.measurands_id
-        , 'units', m.units
-        , 'name', m.measurand
-        ) as parameter
-        , json_build_object(
-          'sd', h.value_sd
-        , 'min', h.value_min
-        , 'q02', h.value_p02
-        , 'q25', h.value_p25
-        , 'median', h.value_p50
-        , 'q75', h.value_p75
-        , 'q98', h.value_p98
-        , 'max', h.value_max
-        ) as summary
-        , sig_digits(h.value_avg, 2) as value
-        , calculate_coverage(
-          h.value_count
-        , s.data_averaging_period_seconds
-        , s.data_logging_period_seconds
-        , 1 * 3600
-        )||jsonb_build_object(
-          'datetime_from', get_datetime_object(h.first_datetime, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
-        ) as coverage
-        {query.fields()}
-        FROM hourly_data h
-        JOIN sensors s USING (sensors_id)
-        JOIN sensor_systems sy USING (sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        JOIN measurands m ON (m.measurands_id = s.measurands_id)
-        {query.where()}
-        ORDER BY datetime
-        {query.pagination()}
-        """
-        return await db.fetchPage(sql, query.params())
-
-
-async def fetch_aggregate_hours(query, aggregate_to, db):
-    if aggregate_to == 'year':
-        dur = "1year"
-        expected_hours = 24 * 365.24
-        interval_seconds = 3600 * 24 * 365.24
-    elif aggregate_to == 'day':
-        dur = "24:00:00"
-        interval_seconds = 3600 * 24
-    else:
-        raise Exception(f'{aggregate_to} is not supported')
-
-    sql = f"""
-        WITH meas AS (
-        SELECT
-        sy.sensor_nodes_id
-        , s.measurands_id
-        , sn.timezone
-        , truncate_timestamp(datetime, :period_name, sn.timezone) as datetime
-        , AVG(s.data_averaging_period_seconds) as avg_seconds
-        , AVG(s.data_logging_period_seconds) as log_seconds
-        , MAX(truncate_timestamp(datetime, '{aggregate_to}', sn.timezone, '1{aggregate_to}'::interval))
-           as last_period
-        , MIN(timezone(sn.timezone, datetime - '1sec'::interval)) as first_datetime
-        , MAX(timezone(sn.timezone, datetime - '1sec'::interval)) as last_datetime
-        , COUNT(1) as value_count
-        , AVG(value_avg) as value_avg
-        , STDDEV(value_avg) as value_sd
-        , MIN(value_avg) as value_min
-        , MAX(value_avg) as value_max
-        , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value_avg) as value_p02
-        , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value_avg) as value_p25
-        , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value_avg) as value_p50
-        , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
-        , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
-        , current_timestamp as calculated_on
-        FROM hourly_data m
-        JOIN sensors s ON (m.sensors_id = s.sensors_id)
-        JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        {query.where()}
-        GROUP BY 1, 2, 3, 4)
-        SELECT t.sensor_nodes_id
-        ----------
-        , json_build_object(
-            'label', '1 {aggregate_to}'
-            , 'datetime_from', get_datetime_object(datetime, t.timezone)
-            , 'datetime_to', get_datetime_object(last_period, t.timezone)
-            , 'interval',  '{dur}'
-            ) as period
-        ----------
+    GROUP BY 1, 2, 3, 4, 5, 6, 7, 8)
+    -----------------------------------------
+    -- And finally we tie it all together
+    -----------------------------------------
+    SELECT 
+        o.sensors_id
         , sig_digits(value_avg, 2) as value
-        -----------
         , json_build_object(
-            'id', t.measurands_id
-            , 'units', m.units
-            , 'name', m.measurand
+            'id', o.measurands_id
+            , 'units', o.units
+            , 'name', o.measurand
         ) as parameter
-        ---------
         , json_build_object(
-            'sd', t.value_sd
-           , 'min', t.value_min
-           , 'q02', t.value_p02
-           , 'q25', t.value_p25
-           , 'median', t.value_p50
-           , 'q75', t.value_p75
-           , 'q98', t.value_p98
-           , 'max', t.value_max
+            'sd', o.value_sd
+            , 'min', o.value_min
+            , 'q02', o.value_p02
+            , 'q25', o.value_p25
+            , 'median', o.value_p50
+            , 'q75', o.value_p75
+            , 'q98', o.value_p98
+            , 'max', o.value_max
         ) as summary
-        --------
+        , json_build_object(
+            'label', e.factor
+            , 'datetime_from', get_datetime_object(e.period_first, o.timezone)
+            , 'datetime_to', get_datetime_object(e.period_last, o.timezone)
+            , 'interval', :period_name
+        ) as period
         , calculate_coverage(
-            value_count::int
-            , {interval_seconds}
-            , {interval_seconds}
-            , EXTRACT(EPOCH FROM last_period - datetime)
-        )||jsonb_build_object(
-                'datetime_from', get_datetime_object(first_datetime, t.timezone)
-                , 'datetime_to', get_datetime_object(last_datetime, t.timezone)
-                ) as coverage
-        {query.total()}
-        FROM meas t
-        JOIN measurands m ON (t.measurands_id = m.measurands_id)
+            o.n::int
+            , o.data_averaging_period_seconds
+            , o.data_logging_period_seconds
+            , e.n * 3600.0) ||
+        jsonb_build_object(
+            'datetime_from', get_datetime_object(o.coverage_first, o.timezone)
+            , 'datetime_to', get_datetime_object(o.coverage_last, o.timezone)
+        ) as coverage
+        FROM expected e
+        JOIN observed o ON (e.factor = o.factor)
         {query.pagination()}
     """
-    params = query.params()
+
     return await db.fetchPage(sql, query.params())
-
-
-async def fetch_aggregate_days(query, aggregate_to, db):
-    if aggregate_to == 'year':
-        dur = "1year"
-        expected_hours = 24 * 365.24
-        interval_seconds = 3600 * 24 * 365.24
-    else:
-        raise Exception(f'{aggregate_to} is not supported')
-
-    sql = f"""
-        WITH meas AS (
-        SELECT
-        sy.sensor_nodes_id
-        , s.measurands_id
-        , sn.timezone
-        , truncate_timestamp(datetime, :period_name, sn.timezone) as datetime
-        , AVG(s.data_averaging_period_seconds) as avg_seconds
-        , AVG(s.data_logging_period_seconds) as log_seconds
-        , MAX(truncate_timestamp(datetime, '{aggregate_to}', sn.timezone, '1{aggregate_to}'::interval))
-           as last_period
-        , MIN(timezone(sn.timezone, datetime - '1sec'::interval)) as first_datetime
-        , MAX(timezone(sn.timezone, datetime - '1sec'::interval)) as last_datetime
-        , COUNT(1) as value_count
-        , AVG(value_avg) as value_avg
-        , STDDEV(value_avg) as value_sd
-        , MIN(value_avg) as value_min
-        , MAX(value_avg) as value_max
-        , PERCENTILE_CONT(0.02) WITHIN GROUP(ORDER BY value_avg) as value_p02
-        , PERCENTILE_CONT(0.25) WITHIN GROUP(ORDER BY value_avg) as value_p25
-        , PERCENTILE_CONT(0.5) WITHIN GROUP(ORDER BY value_avg) as value_p50
-        , PERCENTILE_CONT(0.75) WITHIN GROUP(ORDER BY value_avg) as value_p75
-        , PERCENTILE_CONT(0.98) WITHIN GROUP(ORDER BY value_avg) as value_p98
-        , current_timestamp as calculated_on
-        FROM hourly_data m
-        JOIN sensors s ON (m.sensors_id = s.sensors_id)
-        JOIN sensor_systems sy ON (s.sensor_systems_id = sy.sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        {query.where()}
-        GROUP BY 1, 2, 3, 4)
-        SELECT t.sensor_nodes_id
-        ----------
-        , json_build_object(
-            'label', '1 {aggregate_to}'
-            , 'datetime_from', get_datetime_object(datetime, t.timezone)
-            , 'datetime_to', get_datetime_object(last_period, t.timezone)
-            , 'interval',  '{dur}'
-            ) as period
-        ----------
-        , sig_digits(value_avg, 2) as value
-        -----------
-        , json_build_object(
-            'id', t.measurands_id
-            , 'units', m.units
-            , 'name', m.measurand
-        ) as parameter
-        ---------
-        , json_build_object(
-            'sd', t.value_sd
-           , 'min', t.value_min
-           , 'q02', t.value_p02
-           , 'q25', t.value_p25
-           , 'median', t.value_p50
-           , 'q75', t.value_p75
-           , 'q98', t.value_p98
-           , 'max', t.value_max
-        ) as summary
-        --------
-        , calculate_coverage(
-            value_count::int
-            , {interval_seconds}
-            , {interval_seconds}
-            , EXTRACT(EPOCH FROM last_period - datetime)
-        )||jsonb_build_object(
-                'datetime_from', get_datetime_object(first_datetime, t.timezone)
-                , 'datetime_to', get_datetime_object(last_datetime, t.timezone)
-                ) as coverage
-        {query.total()}
-        FROM meas t
-        JOIN measurands m ON (t.measurands_id = m.measurands_id)
-        {query.pagination()}
-    """
-    params = query.params()
-    return await db.fetchPage(sql, query.params())
-
-
-async def fetch_days(query, db):
-        sql = f"""
-        SELECT sn.id
-        , json_build_object(
-        'label', '1day'
-        , 'datetime_from', get_datetime_object(h.datetime - '1day'::interval, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.datetime, sn.timezone)
-        , 'interval',  '24:00:00'
-        ) as period
-        , json_build_object(
-        'id', s.measurands_id
-        , 'units', m.units
-        , 'name', m.measurand
-        ) as parameter
-        , json_build_object(
-          'sd', h.value_sd
-        , 'min', h.value_min
-        , 'q02', h.value_p02
-        , 'q25', h.value_p25
-        , 'median', h.value_p50
-        , 'q75', h.value_p75
-        , 'q98', h.value_p98
-        , 'max', h.value_max
-        ) as summary
-        , sig_digits(h.value_avg, 2) as value
-        , calculate_coverage(
-          h.value_count
-        , s.data_averaging_period_seconds
-        , s.data_logging_period_seconds
-        , 24 * 3600
-        )||jsonb_build_object(
-          'datetime_from', get_datetime_object(h.first_datetime, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
-        ) as coverage
-        {query.fields()}
-        FROM daily_data h
-        JOIN sensors s USING (sensors_id)
-        JOIN sensor_systems sy USING (sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        JOIN measurands m ON (m.measurands_id = s.measurands_id)
-        {query.where()}
-        ORDER BY datetime
-        {query.pagination()}
-        """
-        return await db.fetchPage(sql, query.params())
-
-
-def aggregate_days(query, aggregate_to, db):
-    ...
-
-
-async def fetch_years(query, db):
-        sql = f"""
-        SELECT sn.id
-        , json_build_object(
-        'label', '1year'
-        , 'datetime_from', get_datetime_object(h.datetime - '1year'::interval, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.datetime, sn.timezone)
-        , 'interval',  '1 year'
-        ) as period
-        , json_build_object(
-        'id', s.measurands_id
-        , 'units', m.units
-        , 'name', m.measurand
-        ) as parameter
-        , json_build_object(
-          'sd', h.value_sd
-        , 'min', h.value_min
-        , 'q02', h.value_p02
-        , 'q25', h.value_p25
-        , 'median', h.value_p50
-        , 'q75', h.value_p75
-        , 'q98', h.value_p98
-        , 'max', h.value_max
-        ) as summary
-        , sig_digits(h.value_avg, 2) as value
-        , calculate_coverage(
-          h.value_count
-        , s.data_averaging_period_seconds
-        , s.data_logging_period_seconds
-        , 3600 * 24 * 365.24
-        )||jsonb_build_object(
-          'datetime_from', get_datetime_object(h.first_datetime, sn.timezone)
-        , 'datetime_to', get_datetime_object(h.last_datetime, sn.timezone)
-        ) as coverage
-        {query.fields()}
-        FROM yearly_data h
-        JOIN sensors s USING (sensors_id)
-        JOIN sensor_systems sy USING (sensor_systems_id)
-        JOIN locations_view_cached sn ON (sy.sensor_nodes_id = sn.id)
-        JOIN measurands m ON (m.measurands_id = s.measurands_id)
-        {query.where()}
-        ORDER BY datetime
-        {query.pagination()}
-        """
-        return await db.fetchPage(sql, query.params())
-
-
-def aggregate_years(query, aggregate_to, db):
-    ...

--- a/openaq_api/openaq_api/v3/routers/trends.py
+++ b/openaq_api/openaq_api/v3/routers/trends.py
@@ -9,8 +9,8 @@ from openaq_api.v3.models.responses import TrendsResponse
 logger = logging.getLogger("trends")
 
 from openaq_api.v3.models.queries import (
-    DateFromQuery,
-    DateToQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
     Paging,
     PeriodNameQuery,
     QueryBaseModel,
@@ -44,8 +44,8 @@ class LocationTrendsQueries(
     Paging,
     LocationPathQuery,
     ParameterPathQuery,
-    DateFromQuery,
-    DateToQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
     PeriodNameQuery,
 ):
     ...

--- a/openaq_api/requirements_dev.txt
+++ b/openaq_api/requirements_dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest
 httpx
+pytest-xdist

--- a/openaq_api/tests/test_sensor_measurements.py
+++ b/openaq_api/tests/test_sensor_measurements.py
@@ -156,11 +156,14 @@ class TestDays:
 
 
     def test_aggregated_moy_good(self, client):
-        response = client.get(f"/v3/sensors/{sensors_id}/days/monthofyear?date_from=2022-01-01")
+        response = client.get(f"/v3/sensors/{sensors_id}/days/monthofyear?date_from=2022-01-01&date_to=2022-12-31")
         assert response.status_code == 200
         data = json.loads(response.content).get('results', [])
         assert len(data) == 12
         row = data[0]
+        period = row['period']['label']
+        print(row)
+
         assert row['coverage']['expectedCount'] == 31
         assert row['coverage']['observedCount'] == 31
         assert row['coverage']['percentComplete'] == 100

--- a/openaq_api/tests/test_sensor_measurements.py
+++ b/openaq_api/tests/test_sensor_measurements.py
@@ -18,7 +18,7 @@ class TestMeasurements:
         response = client.get(f"/v3/sensors/{sensors_id}/measurements")
         assert response.status_code == 200
         data = json.loads(response.content).get('results', [])
-        assert len(data) > 0
+        assert len(data) > 0, "response did not have at least one record"
 
     def test_aggregated_hourly_good(self, client):
         response = client.get(f"/v3/sensors/{sensors_id}/measurements/hourly")
@@ -90,10 +90,18 @@ class TestHours:
         assert len(data) == 7
 
     def test_aggregated_moy_good(self, client):
-        response = client.get(f"/v3/sensors/{sensors_id}/hours/monthofyear?datetime_from=2022-01-01")
+        response = client.get(f"/v3/sensors/{sensors_id}/hours/monthofyear?datetime_from=2022-01-01&datetime_to=2023-01-01")
         assert response.status_code == 200
         data = json.loads(response.content).get('results', [])
         assert len(data) == 12
+
+        row = data[0]
+        # hours are time ending
+        assert row['coverage']['datetimeFrom']['local'] == '2022-01-02T00:00:00-10:00'
+        assert row['coverage']['datetimeTo']['local'] == '2022-02-01T00:00:00-10:00'
+        assert row['period']['datetimeFrom']['local'] == '2022-01-01T00:00:00-10:00'
+        assert row['period']['datetimeTo']['local'] == '2022-02-01T00:00:00-10:00'
+
 
 
 class TestDays:
@@ -139,6 +147,10 @@ class TestDays:
         assert row['coverage']['percentComplete'] == 100
         assert row['coverage']['percentComplete'] == row['coverage']['percentCoverage']
 
+        assert row['coverage']['datetimeFrom']['local'] == '2022-01-01T00:00:00-10:00'
+        assert row['coverage']['datetimeTo']['local'] == '2023-01-01T00:00:00-10:00'
+        assert row['period']['datetimeFrom']['local'] == '2022-01-01T00:00:00-10:00'
+        assert row['period']['datetimeTo']['local'] == '2023-01-01T00:00:00-10:00'
 
     def test_aggregated_dow_good(self, client):
         response = client.get(f"/v3/sensors/{sensors_id}/days/dayofweek?date_from=2022-01-01&date_to=2022-12-31")
@@ -162,7 +174,11 @@ class TestDays:
         assert len(data) == 12
         row = data[0]
         period = row['period']['label']
-        print(row)
+
+        assert row['coverage']['datetimeFrom']['local'] == '2022-01-01T00:00:00-10:00'
+        assert row['coverage']['datetimeTo']['local'] == '2022-02-01T00:00:00-10:00'
+        assert row['period']['datetimeFrom']['local'] == '2022-01-01T00:00:00-10:00'
+        assert row['period']['datetimeTo']['local'] == '2022-02-01T00:00:00-10:00'
 
         assert row['coverage']['expectedCount'] == 31
         assert row['coverage']['observedCount'] == 31

--- a/openaq_api/tests/test_sensor_measurements.py
+++ b/openaq_api/tests/test_sensor_measurements.py
@@ -1,0 +1,51 @@
+from fastapi.testclient import TestClient
+import json
+import time
+import pytest
+from openaq_api.main import app
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+sensors_id = 7223
+
+class TestMeasurements:
+    def test_measurements_raw_good(self, client):
+        response = client.get(f"/v3/sensors/{sensors_id}/measurements")
+        assert response.status_code == 200
+
+    def test_measurements_raw_aggregated_hourly_good(self, client):
+        response = client.get(f"/v3/sensors/{sensors_id}/measurements/hourly")
+        assert response.status_code == 200
+
+    def test_measurements_raw_aggregated_daily_good(self, client):
+        response = client.get(f"/v3/sensors/{sensors_id}/measurements/daily")
+        assert response.status_code == 200
+
+    def test_measurements_hours_good(self, client):
+        response = client.get(f"/v3/sensors/{sensors_id}/hours")
+        assert response.status_code == 200
+
+    def test_measurements_hours_aggregated_daily_good(self, client):
+        response = client.get(f"/v3/sensors/{sensors_id}/hours/daily?date_to=2024-02-01&date_from=2024-01-01")
+        assert response.status_code == 200
+
+    def test_measurements_hours_aggregated_yearly_good(self, client):
+        response = client.get(f"/v3/sensors/{sensors_id}/hours/yearly?date_to=2020-01-01&date_from=2024-01-01")
+        assert response.status_code == 200
+
+    def test_measurements_days_good(self, client):
+        response = client.get(f"/v3/sensors/{sensors_id}/days")
+        assert response.status_code == 200
+
+    def test_measurements_days_aggregated_yearly_good(self, client):
+        response = client.get(f"/v3/sensors/{sensors_id}/days/yearly")
+        assert response.status_code == 200
+
+   # def test_measurements_years_good(self, client):
+   #     response = client.get(f"/v3/sensors/{sensors_id}/years")
+   #     assert response.status_code == 200

--- a/openaq_api/tests/test_sensors.py
+++ b/openaq_api/tests/test_sensors.py
@@ -18,16 +18,10 @@ node = 1
 
 urls = [
     ## v2
-    {"path": "/v3/instruments/3","status": 200},
     {"path": "/v2/averages?locations_id=:node","status": 200},
     {"path": "/v2/locations/:node","status": 200},
     {"path": "/v2/latest/:node","status": 200},
     {"path": "/v2/measurements?location_id=:node","status": 200},
-    ## v3
-    {"path": "/v3/locations/:node","status": 200}, # after
-    {"path": "/v3/locations/:node/measurements","status": 200}, # after
-    {"path": "/v3/sensors/:sensor/measurements","status": 200}, # after
-    {"path": "/v3/sensors/:sensor","status": 200}, # after
     # all of the following have an added where clause
     # and we just want to make sure the sql works
     {"path": "/v2/cities?limit=1","status": 200},
@@ -37,6 +31,12 @@ urls = [
     {"path": "/v3/locations?limit=1","status": 200},
     {"path": "/v3/licenses", "status": 200 },
     {"path": "/v3/licenses/:node", "status": 200 },
+    ## v3
+    {"path": "/v3/instruments/3","status": 200},
+    {"path": "/v3/locations/:node","status": 200}, # after
+    {"path": "/v3/locations/:node/measurements","status": 200}, # after
+    {"path": "/v3/sensors/:sensor/measurements","status": 200}, # after
+    {"path": "/v3/sensors/:sensor","status": 200}, # after
 ]
 
 

--- a/openaq_api/tests/unit/test_v3_queries.py
+++ b/openaq_api/tests/unit/test_v3_queries.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, date
 from zoneinfo import ZoneInfo
 
 import fastapi
@@ -12,6 +12,8 @@ from openaq_api.v3.models.queries import (
     CommaSeparatedList,
     CountryIdQuery,
     CountryIsoQuery,
+    DatetimeFromQuery,
+    DatetimeToQuery,
     DateFromQuery,
     DateToQuery,
     ManufacturersQuery,
@@ -98,20 +100,96 @@ class TestMonitorQuery:
         assert params == {"monitor": None}
 
 
-class TestDateFromQuery:
+class TestDatetimeFromQuery:
     def test_has_value_datetime(self):
-        date_from_query = DateFromQuery(date_from="2022-10-01T14:47:27-00:00")
+        datetime_from_query = DatetimeFromQuery(datetime_from="2022-10-01T14:47:27-00:00")
+        params = datetime_from_query.model_dump()
+        assert params == {
+            "datetime_from": datetime(
+                2022, 10, 1, 14, 47, 27, tzinfo=ZoneInfo("UTC")
+            )
+        }
+
+    def test_has_value_date(self):
+        datetime_from_query = DatetimeFromQuery(datetime_from="2022-10-01")
+        params = datetime_from_query.model_dump()
+        assert params == {"datetime_from": date(2022, 10, 1)}
+
+    def test_no_value(self):
+        datetime_from_query = DatetimeFromQuery()
+        where = datetime_from_query.where()
+        params = datetime_from_query.model_dump()
+        assert where is None
+        assert params == {"datetime_from": None}
+
+    def test_date_where(self):
+        datetime_from_query = DatetimeFromQuery(datetime_from="2022-10-01")
+        where = datetime_from_query.where()
+        assert where == "datetime > (:datetime_from::timestamp AT TIME ZONE timezone)"
+
+    def test_datetime_tz_where(self):
+        datetime_from_query = DatetimeFromQuery(datetime_from="2022-10-01T14:47:27-00:00")
+        where = datetime_from_query.where()
+        assert where == "datetime > :datetime_from"
+
+    def test_datetime_notz_where(self):
+        datetime_from_query = DatetimeFromQuery(datetime_from="2022-10-01T14:47:27")
+        where = datetime_from_query.where()
+        assert where == "datetime > (:datetime_from::timestamp AT TIME ZONE timezone)"
+
+
+class TestDatetimeToQuery:
+    def test_has_value_datetime(self):
+        datetime_to_query = DatetimeToQuery(datetime_to="2022-10-01T14:47:27-00:00")
+        params = datetime_to_query.model_dump()
+        assert params == {
+            "datetime_to": datetime(
+                2022, 10, 1, 14, 47, 27, tzinfo=ZoneInfo("UTC")
+            )
+        }
+
+    def test_has_value_date(self):
+        datetime_to_query = DatetimeToQuery(datetime_to="2022-10-01")
+        params = datetime_to_query.model_dump()
+        assert params == {"datetime_to": date(2022, 10, 1)}
+
+    def test_no_value(self):
+        datetime_to_query = DatetimeToQuery()
+        where = datetime_to_query.where()
+        params = datetime_to_query.model_dump()
+        assert where is None
+        assert params == {"datetime_to": None}
+
+    def test_date_where(self):
+        datetime_to_query = DatetimeToQuery(datetime_to="2022-10-01")
+        where = datetime_to_query.where()
+        assert where == "datetime <= (:datetime_to::timestamp AT TIME ZONE timezone)"
+
+    def test_datetime_tz_where(self):
+        datetime_to_query = DatetimeToQuery(datetime_to="2022-10-01T14:47:27-00:00")
+        where = datetime_to_query.where()
+        assert where == "datetime <= :datetime_to"
+
+    def test_datetime_notz_where(self):
+        datetime_to_query = DatetimeToQuery(datetime_to="2022-10-01T14:47:27")
+        where = datetime_to_query.where()
+        assert where == "datetime <= (:datetime_to::timestamp AT TIME ZONE timezone)"
+
+
+class TestDateFromQuery:
+    def test_has_value_date(self):
+        date_from_query = DateFromQuery(date_from="2022-10-01")
         params = date_from_query.model_dump()
         assert params == {
-            "date_from": datetime.datetime(
-                2022, 10, 1, 14, 47, 27, tzinfo=ZoneInfo("UTC")
+            "date_from": date(
+                2022, 10, 1
             )
         }
 
     def test_has_value_date(self):
         date_from_query = DateFromQuery(date_from="2022-10-01")
         params = date_from_query.model_dump()
-        assert params == {"date_from": datetime.date(2022, 10, 1)}
+        assert params == {"date_from": date(2022, 10, 1)}
 
     def test_no_value(self):
         date_from_query = DateFromQuery()
@@ -123,25 +201,25 @@ class TestDateFromQuery:
     def test_date_where(self):
         date_from_query = DateFromQuery(date_from="2022-10-01")
         where = date_from_query.where()
-        assert where == "datetime > (:date_from::timestamp AT TIME ZONE timezone)"
+        assert where == "datetime >= :date_from"
 
-    def test_datetime_tz_where(self):
+    def test_date_tz_where(self):
         date_from_query = DateFromQuery(date_from="2022-10-01T14:47:27-00:00")
         where = date_from_query.where()
-        assert where == "datetime > :date_from"
+        assert where == "datetime >= :date_from::date"
 
-    def test_datetime_notz_where(self):
+    def test_date_notz_where(self):
         date_from_query = DateFromQuery(date_from="2022-10-01T14:47:27")
         where = date_from_query.where()
-        assert where == "datetime > (:date_from::timestamp AT TIME ZONE timezone)"
+        assert where == "datetime >= :date_from::date"
 
 
 class TestDateToQuery:
-    def test_has_value_datetime(self):
+    def test_has_value_date(self):
         date_to_query = DateToQuery(date_to="2022-10-01T14:47:27-00:00")
         params = date_to_query.model_dump()
         assert params == {
-            "date_to": datetime.datetime(
+            "date_to": date(
                 2022, 10, 1, 14, 47, 27, tzinfo=ZoneInfo("UTC")
             )
         }
@@ -149,7 +227,7 @@ class TestDateToQuery:
     def test_has_value_date(self):
         date_to_query = DateToQuery(date_to="2022-10-01")
         params = date_to_query.model_dump()
-        assert params == {"date_to": datetime.date(2022, 10, 1)}
+        assert params == {"date_to": date(2022, 10, 1)}
 
     def test_no_value(self):
         date_to_query = DateToQuery()
@@ -159,19 +237,19 @@ class TestDateToQuery:
         assert params == {"date_to": None}
 
     def test_date_where(self):
-        date_to_query = DateToQuery(date_to="2022-10-01")
-        where = date_to_query.where()
-        assert where == "datetime <= (:date_to::timestamp AT TIME ZONE timezone)"
-
-    def test_datetime_tz_where(self):
-        date_to_query = DateToQuery(date_to="2022-10-01T14:47:27-00:00")
-        where = date_to_query.where()
+        date_from_query = DateToQuery(date_to="2022-10-01")
+        where = date_from_query.where()
         assert where == "datetime <= :date_to"
 
-    def test_datetime_notz_where(self):
+    def test_date_tz_where(self):
+        date_to_query = DateToQuery(date_to="2022-10-01T14:47:27-00:00")
+        where = date_to_query.where()
+        assert where == "datetime <= :date_to::date"
+
+    def test_date_notz_where(self):
         date_to_query = DateToQuery(date_to="2022-10-01T14:47:27")
         where = date_to_query.where()
-        assert where == "datetime <= (:date_to::timestamp AT TIME ZONE timezone)"
+        assert where == "datetime <= :date_to::date"
 
 
 class TestParametersQuery:


### PR DESCRIPTION
Pull request fixes issues for annual averaging but we also discussed updated endpoints as well, instead of using the `period_name`. 

For the path updates I suggest the following
`sensors/1/measurements` -- raw data for sensor 1
`sensors/1/hours` -- hourly data for sensor 1
`sensors/1/days`-- daily data for sensor 1
`sensors/1/years` -- annual data for sensor 1
`sensors/1/measurements/hourly` -- raw data aggregated to hourly for sensor 1 (really an alias for hourly data)
`sensors/1/measurements/daily` -- raw data aggregated to daily for sensor 1, we dont store this so this would be novel
`sensors/1/days/yearly` -- daily data for sensor 1 aggregated to a year
The nice thing about above is that it would turn the `period_name` into another resource. The only thing I worry about for something like this is that the combination of the base/aggregation could be confusing but it would have its own endpoint and therefor we could offer a great description.
Lets say that a user wants to see the annual average of daily values, it would be
`sensors/1/days/yearly`
which reads better to me than
`sensors/1/measurements/daily?period_name=year`
`sensors/1/daily?period_name=year`