### PR TITLE
My HW6b contributions (rate limit headers, request ID, timing metrics)

### DIFF
--- a/tests/test_check_headers.py
+++ b/tests/test_check_headers.py
@@ -1,0 +1,67 @@
+from fastapi.testclient import TestClient
+from openaq_api.main import app
+
+
+def test_request_id_is_added():
+    client = TestClient(app)
+    headers_with_key = {"X-API-Key": "test-key"}
+
+    # Use safe and lightweight root endpoint
+    endpoint = "/"
+
+    # Case 1: Custom request ID from client
+    custom_id = "test-id-123"
+    resp = client.get(endpoint, headers={**headers_with_key, "X-Request-ID": custom_id})
+    assert resp.status_code == 200
+    assert resp.headers["X-Request-ID"] == custom_id
+
+    # Case 2: Auto-generated request ID from server
+    resp2 = client.get(endpoint, headers=headers_with_key)
+    assert resp2.status_code == 200
+    assert "X-Request-ID" in resp2.headers
+    assert len(resp2.headers["X-Request-ID"]) >= 10
+
+
+def test_api_version_header_present():
+    client = TestClient(app)
+    headers = {"X-API-Key": "test-key"}
+
+    # Use root endpoint to verify fallback logic
+    response = client.get("/", headers=headers)
+
+    assert response.status_code == 200
+    assert "X-API-Version" in response.headers
+    assert response.headers["X-API-Version"] == "v2"  # fallback/default version
+
+def test_response_time_header():
+    client = TestClient(app)
+    headers = {"X-API-Key": "test-key"}
+    response = client.get("/", headers=headers)
+
+    assert response.status_code == 200
+    assert "X-Response-Time" in response.headers
+    assert response.headers["X-Response-Time"].endswith("ms")
+
+def test_timing_metrics_available():
+    client = TestClient(app)
+    headers = {"X-API-Key": "test-key"}
+
+    # Hit a few endpoints to generate timing data
+    for _ in range(3):
+        client.get("/", headers=headers)
+
+    # Check metrics
+    metrics = client.get("/metrics/timing", headers=headers)
+    assert metrics.status_code == 200
+    body = metrics.json()
+
+    # Flexible assertion: check that at least one key is for "/"
+    matching_keys = [k for k in body.keys() if k.endswith("/")]
+    assert matching_keys, "Expected a key ending in '/', got: {}".format(body.keys())
+
+    for k in matching_keys:
+        assert "count" in body[k]
+        assert "avg_ms" in body[k]
+
+
+

--- a/tests/test_fake429.py
+++ b/tests/test_fake429.py
@@ -1,0 +1,13 @@
+from fastapi.testclient import TestClient
+from openaq_api.main import app
+
+client = TestClient(app)  # ✅ spins up a test instance of your FastAPI app
+
+def test_fake_429_headers():
+    headers = {"X-API-Key": "test-key"}  # ✅ sets a mock valid API key
+    response = client.get("/fake429", headers=headers)  # ⬅️ hits the fake test endpoint you added
+
+    assert response.status_code == 429  # ✅ verifies that the server responds with HTTP 429
+    assert response.headers["X-RateLimit-Limit"] == "60"  # ✅ checks the max rate limit value
+    assert response.headers["X-RateLimit-Remaining"] == "0"  # ✅ checks that 0 requests remain
+    assert "X-RateLimit-Reset" in response.headers  # ✅ ensures a reset timer is present

--- a/tests/test_redis_error.py
+++ b/tests/test_redis_error.py
@@ -1,0 +1,54 @@
+import json
+import pytest
+from fastapi.testclient import TestClient
+from contextlib import asynccontextmanager
+import openaq_api.dependencies  # must import before patching logger
+
+logs = []
+
+@pytest.fixture(autouse=True)
+def patch_logger(monkeypatch):
+    monkeypatch.setattr(
+        openaq_api.dependencies.logger,
+        "error",
+        lambda msg, *a, **kw: logs.append(msg.decode() if isinstance(msg, bytes) else str(msg))
+    )
+
+class FailingRedis:
+    async def sismember(self, key_set, api_key): return 1
+    async def hget(self, api_key, field): return "5"
+    async def get(self, key): return None
+    async def ttl(self, key): return 60
+    def pipeline(self):
+        @asynccontextmanager
+        async def broken_pipeline():
+            class Pipe:
+                async def incr(self, key): raise RuntimeError("redis error during pipeline")
+                def expire(self, key, ttl): return self
+                async def execute(self): return [1, True]
+            yield Pipe()
+        return broken_pipeline()
+
+@pytest.fixture
+def test_client_with_failing_redis():
+    from openaq_api.main import app
+    app.state.redis = FailingRedis()
+    return TestClient(app)
+
+def test_redis_error_logging(test_client_with_failing_redis):
+    logs.clear()
+
+    response = test_client_with_failing_redis.get("/_test-redis-error", headers={"X-API-Key": "test-key"})
+    assert response.status_code == 200
+
+    print("Captured logs:", logs)
+
+    for log in logs:
+        try:
+            parsed = json.loads(log)
+            if "redis error" in parsed.get("detail", "").lower():
+                return  # ✅ success
+        except Exception as e:
+            print("⚠️ Could not parse:", log, e)
+
+    pytest.fail("Redis error was not logged")


### PR DESCRIPTION
This pull request adds a few improvements to the OpenAQ API v2 as part of a course project (EECS 481 - Software Engineering, University of Michigan):

 - Adds rate limit headers to 429 responses (x-ratelimit-limit, x-ratelimit-remaining, etc.)

 - Adds X-Request-ID and X-Response-Time headers to every response for easier debugging

 - Adds a new /metrics/timing endpoint to track average response time per route

 - Includes test cases for all added features

Let me know if there’s anything I should adjust! Thanks for maintaining this awesome project and I think it's really cool what you're doing, especially since this is open source as well!  I wish you the best of luck with the refactor!  